### PR TITLE
Fix the initialisation of Rnd in FlatZinc

### DIFF
--- a/changelog.in
+++ b/changelog.in
@@ -66,6 +66,16 @@
 #    optional section in the html page.
 #
 
+[ENTRY]
+Module: flatzinc
+What:   bug
+Rank:   minor
+Thanks: Jip J. Dekker
+[DESCRIPTION]
+Fixed the initialisation of the random number generator for the
+FlatZinc executable. This fix ensures the generator is always
+initialised.
+
 [RELEASE]
 Version: 6.0.0
 Date: 2018-02-´23

--- a/gecode/flatzinc/flatzinc.cpp
+++ b/gecode/flatzinc/flatzinc.cpp
@@ -88,8 +88,8 @@ namespace std {
 
 namespace Gecode { namespace FlatZinc {
 
-  // Unitialized default random number generator
-  Rnd defrnd;
+  // Default random number generator
+  Rnd defrnd(0);
 
   /**
    * \brief Branching on the introduced variables

--- a/gecode/flatzinc/parser.tab.cpp
+++ b/gecode/flatzinc/parser.tab.cpp
@@ -444,7 +444,7 @@ namespace Gecode { namespace FlatZinc {
     }
 
     if (fzs == NULL) {
-      fzs = new FlatZincSpace();
+      fzs = new FlatZincSpace(rnd);
     }
     ParserState pp(data, sbuf.st_size, err, fzs);
 #else

--- a/gecode/flatzinc/parser.yxx
+++ b/gecode/flatzinc/parser.yxx
@@ -419,7 +419,7 @@ namespace Gecode { namespace FlatZinc {
     }
 
     if (fzs == NULL) {
-      fzs = new FlatZincSpace();
+      fzs = new FlatZincSpace(rnd);
     }
     ParserState pp(data, sbuf.st_size, err, fzs);
 #else


### PR DESCRIPTION
This commit fixes the passing of the `rnd` value from main and initialises the default random number generator.

_This PR is made after some issues of an un-initialised random number generator while developing an `fzn-gecode` extension_