### PR TITLE
Minimal patch for support counting-based search.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6,8 +6,12 @@ dnl
 dnl Main authors:
 dnl   Guido Tack <tack@gecode.org>
 dnl
+dnl Contributing authors:
+dnl   Samuel Gagnon <samuel.gagnon92@gmail.com>
+dnl
 dnl Copyright:
 dnl   Guido Tack, 2004, 2005
+dnl   Samuel Gagnon, 2018
 dnl
 dnl Last modified:
 dnl   $Date$
@@ -286,6 +290,7 @@ dnl ------------------------------------------------------------------
 AC_GECODE_MPFR
 AC_GECODE_QT
 AC_GECODE_GIST
+AC_GECODE_CBS
 AC_GECODE_CPPROFILER
 AC_GECODE_FLEXBISON
 AC_FUNC_MMAP

--- a/configure.ac.in
+++ b/configure.ac.in
@@ -282,6 +282,7 @@ dnl ------------------------------------------------------------------
 AC_GECODE_MPFR
 AC_GECODE_QT
 AC_GECODE_GIST
+AC_GECODE_CBS
 AC_GECODE_CPPROFILER
 AC_GECODE_FLEXBISON
 AC_FUNC_MMAP

--- a/configure.ac.in
+++ b/configure.ac.in
@@ -2,8 +2,12 @@ dnl
 dnl Main authors:
 dnl   Guido Tack <tack@gecode.org>
 dnl
+dnl Contributing authors:
+dnl   Samuel Gagnon <samuel.gagnon92@gmail.com>
+dnl
 dnl Copyright:
 dnl   Guido Tack, 2004, 2005
+dnl   Samuel Gagnon, 2018
 dnl
 dnl Last modified:
 dnl   $Date$

--- a/gecode.m4
+++ b/gecode.m4
@@ -1396,6 +1396,31 @@ AC_DEFUN([AC_GECODE_GIST],
   fi
 ])
 
+dnl
+dnl Macro:
+dnl   AC_GECODE_CBS
+dnl
+dnl Description:
+dnl   Produces the configure switch --enable-cbs
+dnl   for compiling with support for counting-based search.
+dnl
+dnl Authors:
+dnl   Samuel Gagnon <samuel.gagnon92@gmail.com>
+AC_DEFUN([AC_GECODE_CBS],
+  [
+  AC_ARG_ENABLE([cbs],
+    AC_HELP_STRING([--enable-cbs],
+      [build with support for counting-based search @<:@default=no@:>@]))
+  AC_MSG_CHECKING(whether to build with support for cbs)
+  if test "${enable_cbs:-no}" = "yes"; then
+    AC_MSG_RESULT(yes)
+    AC_SUBST(enable_cbs, yes)
+    AC_DEFINE([GECODE_HAS_CBS],[],[Whether counting-based search support available])
+  else
+    AC_MSG_RESULT(no)
+  fi
+])
+
 dnl Macro:
 dnl   AC_GECODE_CPPROFILER
 dnl

--- a/gecode.m4
+++ b/gecode.m4
@@ -2,8 +2,12 @@ dnl
 dnl Main authors:
 dnl   Guido Tack <tack@gecode.org>
 dnl
+dnl Contributing authors:
+dnl   Samuel Gagnon <samuel.gagnon92@gmail.com>
+dnl
 dnl Copyright:
 dnl   Guido Tack, 2004, 2005
+dnl   Samuel Gagnon, 2018
 dnl
 dnl Last modified:
 dnl   $Date$

--- a/gecode/int/view.hpp
+++ b/gecode/int/view.hpp
@@ -150,6 +150,10 @@ namespace Gecode { namespace Int {
     int med(void) const;
     /// Return assigned value (only if assigned)
     int val(void) const;
+#ifdef GECODE_HAS_CBS
+    /// Return reverse transformation of value according to view
+    int baseval(int val) const;
+#endif
 
     /// Return size (cardinality) of domain
     unsigned int size(void) const;
@@ -297,6 +301,10 @@ namespace Gecode { namespace Int {
     int med(void) const;
     /// Return assigned value (only if assigned)
     int val(void) const;
+#ifdef GECODE_HAS_CBS
+    /// Return reverse transformation of value according to view
+    int baseval(int val) const;
+#endif
 
     /// Return size (cardinality) of domain
     unsigned int size(void) const;
@@ -451,6 +459,10 @@ namespace Gecode { namespace Int {
     int med(void) const;
     /// Return assigned value (only if assigned)
     int val(void) const;
+#ifdef GECODE_HAS_CBS
+    /// Return reverse transformation of value according to view
+    int baseval(int val) const;
+#endif
 
     /// Return size (cardinality) of domain
     unsigned int size(void) const;
@@ -700,6 +712,10 @@ namespace Gecode { namespace Int {
     Val med(void) const;
     /// Return assigned value (only if assigned)
     Val val(void) const;
+#ifdef GECODE_HAS_CBS
+    /// Return reverse transformation of value according to view
+    Val baseval(Val val) const;
+#endif
 
     /// Return size (cardinality) of domain
     UnsVal size(void) const;
@@ -1145,6 +1161,10 @@ namespace Gecode { namespace Int {
     int med(void) const;
     /// Return assigned value (only if assigned)
     int val(void) const;
+#ifdef GECODE_HAS_CBS
+    /// Return reverse transformation of value according to view
+    int baseval(int val) const;
+#endif
 
     /// Return size (cardinality) of domain
     unsigned int size(void) const;
@@ -1364,6 +1384,10 @@ namespace Gecode { namespace Int {
     int med(void) const;
     /// Return assigned value (only if assigned)
     int val(void) const;
+#ifdef GECODE_HAS_CBS
+    /// Return reverse transformation of value according to view
+    int baseval(int val) const;
+#endif
 
     /// Return size (cardinality) of domain
     unsigned int size(void) const;
@@ -1572,6 +1596,10 @@ namespace Gecode { namespace Int {
     int max(void) const;
     /// Return assigned value (only if assigned)
     int val(void) const;
+#ifdef GECODE_HAS_CBS
+    /// Return reverse transformation of value according to view
+    int baseval(int val) const;
+#endif
     //@}
 
     /// \name Delta information for advisors

--- a/gecode/int/view.hpp
+++ b/gecode/int/view.hpp
@@ -3,8 +3,12 @@
  *  Main authors:
  *     Christian Schulte <schulte@gecode.org>
  *
+ *  Contributing authors:
+ *     Samuel Gagnon <samuel.gagnon92@gmail.com>
+ *
  *  Copyright:
  *     Christian Schulte, 2005
+ *     Samuel Gagnon, 2018
  *
  *  Last modified:
  *     $Date$ by $Author$

--- a/gecode/int/view/bool.hpp
+++ b/gecode/int/view/bool.hpp
@@ -3,8 +3,12 @@
  *  Main authors:
  *     Christian Schulte <schulte@gecode.org>
  *
+ *  Contributing authors:
+ *     Samuel Gagnon <samuel.gagnon92@gmail.com>
+ *
  *  Copyright:
  *     Christian Schulte, 2002
+ *     Samuel Gagnon, 2018
  *
  *  Last modified:
  *     $Date$ by $Author$

--- a/gecode/int/view/bool.hpp
+++ b/gecode/int/view/bool.hpp
@@ -74,6 +74,12 @@ namespace Gecode { namespace Int {
   BoolView::val(void) const {
     return x->val();
   }
+#ifdef GECODE_HAS_CBS
+  forceinline int
+  BoolView::baseval(int val) const {
+    return val;
+  }
+#endif
 
   forceinline unsigned int
   BoolView::size(void) const {

--- a/gecode/int/view/cached.hpp
+++ b/gecode/int/view/cached.hpp
@@ -75,6 +75,13 @@ namespace Gecode { namespace Int {
   CachedView<View>::val(void) const {
     return x.val();
   }
+#ifdef GECODE_HAS_CBS
+  template<class View>
+  forceinline int
+  CachedView<View>::baseval(int val) const {
+    return val;
+  }
+#endif
 
   template<class View>
   forceinline unsigned int

--- a/gecode/int/view/cached.hpp
+++ b/gecode/int/view/cached.hpp
@@ -3,8 +3,12 @@
  *  Main authors:
  *     Guido Tack <tack@gecode.org>
  *
+ *  Contributing authors:
+ *     Samuel Gagnon <samuel.gagnon92@gmail.com>
+ *
  *  Copyright:
  *     Guido Tack, 2011
+ *     Samuel Gagnon, 2018
  *
  *  Last modified:
  *     $Date$ by $Author$

--- a/gecode/int/view/int.hpp
+++ b/gecode/int/view/int.hpp
@@ -3,8 +3,12 @@
  *  Main authors:
  *     Christian Schulte <schulte@gecode.org>
  *
+ *  Contributing authors:
+ *     Samuel Gagnon <samuel.gagnon92@gmail.com>
+ *
  *  Copyright:
  *     Christian Schulte, 2002
+ *     Samuel Gagnon, 2018
  *
  *  Last modified:
  *     $Date$ by $Author$

--- a/gecode/int/view/int.hpp
+++ b/gecode/int/view/int.hpp
@@ -70,6 +70,12 @@ namespace Gecode { namespace Int {
   IntView::val(void) const {
     return x->val();
   }
+#ifdef GECODE_HAS_CBS
+  forceinline int
+  IntView::baseval(int val) const {
+    return val;
+  }
+#endif
 
   forceinline unsigned int
   IntView::size(void) const {

--- a/gecode/int/view/minus.hpp
+++ b/gecode/int/view/minus.hpp
@@ -3,8 +3,12 @@
  *  Main authors:
  *     Christian Schulte <schulte@gecode.org>
  *
+ *  Contributing authors:
+ *     Samuel Gagnon <samuel.gagnon92@gmail.com>
+ *
  *  Copyright:
  *     Christian Schulte, 2003
+ *     Samuel Gagnon, 2018
  *
  *  Last modified:
  *     $Date$ by $Author$

--- a/gecode/int/view/minus.hpp
+++ b/gecode/int/view/minus.hpp
@@ -64,6 +64,12 @@ namespace Gecode { namespace Int {
   MinusView::val(void) const {
     return -x.val();
   }
+#ifdef GECODE_HAS_CBS
+  forceinline int
+  MinusView::baseval(int val) const {
+    return -val;
+  }
+#endif
 
   forceinline unsigned int
   MinusView::width(void) const {

--- a/gecode/int/view/neg-bool.hpp
+++ b/gecode/int/view/neg-bool.hpp
@@ -114,6 +114,12 @@ namespace Gecode { namespace Int {
   NegBoolView::val(void) const {
     return 1-x.val();
   }
+#ifdef GECODE_HAS_CBS
+  forceinline int
+  NegBoolView::baseval(int val) const {
+    return 1-val;
+  }
+#endif
 
 
   /*

--- a/gecode/int/view/neg-bool.hpp
+++ b/gecode/int/view/neg-bool.hpp
@@ -3,8 +3,12 @@
  *  Main authors:
  *     Christian Schulte <schulte@gecode.org>
  *
+ *  Contributing authors:
+ *     Samuel Gagnon <samuel.gagnon92@gmail.com>
+ *
  *  Copyright:
  *     Christian Schulte, 2008
+ *     Samuel Gagnon, 2018
  *
  *  Last modified:
  *     $Date$ by $Author$

--- a/gecode/int/view/offset.hpp
+++ b/gecode/int/view/offset.hpp
@@ -76,6 +76,12 @@ namespace Gecode { namespace Int {
   OffsetView::val(void) const {
     return x.val()+c;
   }
+#ifdef GECODE_HAS_CBS
+  forceinline int
+  OffsetView::baseval(int val) const {
+    return val-c;
+  }
+#endif
 
   forceinline unsigned int
   OffsetView::width(void) const {

--- a/gecode/int/view/offset.hpp
+++ b/gecode/int/view/offset.hpp
@@ -3,8 +3,12 @@
  *  Main authors:
  *     Christian Schulte <schulte@gecode.org>
  *
+ *  Contributing authors:
+ *     Samuel Gagnon <samuel.gagnon92@gmail.com>
+ *
  *  Copyright:
  *     Christian Schulte, 2002
+ *     Samuel Gagnon, 2018
  *
  *  Last modified:
  *     $Date$ by $Author$

--- a/gecode/int/view/scale.hpp
+++ b/gecode/int/view/scale.hpp
@@ -85,6 +85,13 @@ namespace Gecode { namespace Int {
   ScaleView<Val,UnsVal>::val(void) const {
     return static_cast<Val>(x.val()) * a;
   }
+#ifdef GECODE_HAS_CBS
+  template<class Val, class UnsVal>
+  forceinline Val
+  ScaleView<Val,UnsVal>::baseval(Val val) const {
+    return val / a;
+  }
+#endif
 
   template<class Val, class UnsVal>
   forceinline UnsVal

--- a/gecode/int/view/scale.hpp
+++ b/gecode/int/view/scale.hpp
@@ -3,8 +3,12 @@
  *  Main authors:
  *     Christian Schulte <schulte@gecode.org>
  *
+ *  Contributing authors:
+ *     Samuel Gagnon <samuel.gagnon92@gmail.com>
+ *
  *  Copyright:
  *     Christian Schulte, 2002
+ *     Samuel Gagnon, 2018
  *
  *  Last modified:
  *     $Date$ by $Author$

--- a/gecode/kernel/core.cpp
+++ b/gecode/kernel/core.cpp
@@ -3,8 +3,12 @@
  *  Main authors:
  *     Christian Schulte <schulte@gecode.org>
  *
+ *  Contributing authors:
+ *     Samuel Gagnon <samuel.gagnon92@gmail.com>
+ *
  *  Copyright:
  *     Christian Schulte, 2002
+ *     Samuel Gagnon, 2018
  *
  *  Last modified:
  *     $Date$ by $Author$

--- a/gecode/kernel/core.cpp
+++ b/gecode/kernel/core.cpp
@@ -113,6 +113,9 @@ namespace Gecode {
 #endif
 
   Space::Space(void) : mm(ssd.data().sm) {
+#ifdef GECODE_HAS_CBS
+    var_id_counter = 0;
+#endif
 #ifdef GECODE_HAS_VAR_DISPOSE
     for (int i=0; i<AllVarConf::idx_d; i++)
       _vars_d[i] = NULL;
@@ -662,6 +665,9 @@ namespace Gecode {
   Space::Space(Space& s)
     : ssd(s.ssd),
       mm(ssd.data().sm,s.mm,s.pc.p.n_sub*sizeof(Propagator**)),
+#ifdef GECODE_HAS_CBS
+      var_id_counter(s.var_id_counter),
+#endif
       d_fst(&Actor::sentinel) {
 #ifdef GECODE_HAS_VAR_DISPOSE
     for (int i=0; i<AllVarConf::idx_d; i++)

--- a/gecode/kernel/core.hpp
+++ b/gecode/kernel/core.hpp
@@ -1151,6 +1151,35 @@ namespace Gecode {
     /// Return the accumlated failure count
     double afc(void) const;
     //@}
+#ifdef GECODE_HAS_CBS
+    /// \name Marginal distribution
+    //@{
+    /**
+     * \brief Solution distribution
+     *
+     * Computes the marginal distribution for every variable and value in the
+     * propagator. A callback is used to transmit each result.
+     */
+    /// Signature for function transmitting marginal distributions
+    typedef std::function<void(unsigned int prop_id, unsigned int var_id,
+                               int val, double dens)> SendMarginal;
+    virtual void solndistrib(Space& home, SendMarginal send) const;
+    /**
+     * \brief Sum of variable cardinalities
+     *
+     * TODO: This method can be removed if there's a generic way to access
+     * variables in a propagator. Please contact <samuel.gagnon92@gmail.com>
+     *
+     * \param size   Sum of variable cardinalities
+     * \param size_b Sum of variable cardinalities for subset involved
+     *               in branching decisions
+     */
+    /// Signature for function testing if variables are candidates to branching decisions
+    typedef std::function<bool(unsigned int var_id)> InDecision;
+    virtual void domainsizesum(InDecision in, unsigned int& size,
+                               unsigned int& size_b) const;
+    //@}
+#endif
     /// \name Id and group support
     //@{
     /// Return propagator id
@@ -3420,6 +3449,18 @@ namespace Gecode {
   Propagator::afc(void) const {
     return const_cast<Propagator&>(*this).gpi().afc;
   }
+
+#ifdef GECODE_HAS_CBS
+  forceinline void
+  Propagator::solndistrib(Space&, SendMarginal) const {}
+
+  forceinline void
+  Propagator::domainsizesum(InDecision, unsigned int& size,
+                                  unsigned int& size_b) const {
+    size = 0;
+    size_b = 0;
+  }
+#endif
 
   forceinline unsigned int
   Propagator::id(void) const {

--- a/gecode/kernel/core.hpp
+++ b/gecode/kernel/core.hpp
@@ -7,12 +7,14 @@
  *
  *  Contributing authors:
  *     Filip Konvicka <filip.konvicka@logis.cz>
+ *     Samuel Gagnon <samuel.gagnon92@gmail.com>
  *
  *  Copyright:
  *     Christian Schulte, 2002
  *     Guido Tack, 2003
  *     Mikael Lagerkvist, 2006
  *     LOGIS, s.r.o., 2009
+ *     Samuel Gagnon, 2018
  *
  *  Bugfixes provided by:
  *     Alexander Samoilov <alexander_samoilov@yahoo.com>
@@ -1166,9 +1168,6 @@ namespace Gecode {
     virtual void solndistrib(Space& home, SendMarginal send) const;
     /**
      * \brief Sum of variable cardinalities
-     *
-     * TODO: This method can be removed if there's a generic way to access
-     * variables in a propagator. Please contact <samuel.gagnon92@gmail.com>
      *
      * \param size   Sum of variable cardinalities
      * \param size_b Sum of variable cardinalities for subset involved
@@ -4042,11 +4041,13 @@ namespace Gecode {
 
   template<class VIC>
   forceinline
-  VarImp<VIC>::VarImp(
+  VarImp<VIC>::VarImp(Space& home)
 #ifdef GECODE_HAS_CBS
-  Space& home) : var_id(++home.var_id_counter) {
-#else
-  Space&) {
+  : var_id(++home.var_id_counter)
+#endif
+  {
+#ifndef GECODE_HAS_CBS
+    (void) home;
 #endif
     b.base = NULL; entries = 0;
     for (PropCond pc=1; pc<pc_max+2; pc++)

--- a/gecode/kernel/view.hpp
+++ b/gecode/kernel/view.hpp
@@ -58,6 +58,10 @@ namespace Gecode {
     static bool varderived(void);
     /// Return dummy variable implementation of view
     VarImpType* varimp(void) const;
+#ifdef GECODE_HAS_CBS
+    /// Return dummy id
+    unsigned int id(void) const;
+#endif
     //@}
 
     /// \name Domain tests
@@ -146,6 +150,10 @@ namespace Gecode {
     unsigned int degree(void) const;
     /// Return accumulated failure count
     double afc(void) const;
+#ifdef GECODE_HAS_CBS
+    /// Return id of implementation of view
+    unsigned int id(void) const;
+#endif
     //@}
 
     /// \name Domain tests
@@ -245,6 +253,10 @@ namespace Gecode {
     unsigned int degree(void) const;
     /// Return accumulated failure count
     double afc(void) const;
+#ifdef GECODE_HAS_CBS
+    /// Return id of implementation of view
+    unsigned int id(void) const;
+#endif
     //@}
 
     /// \name Domain tests
@@ -381,6 +393,13 @@ namespace Gecode {
   ConstView<View>::varimp(void) const {
     return NULL;
   }
+#ifdef GECODE_HAS_CBS
+  template<class View>
+  forceinline unsigned int
+  ConstView<View>::id(void) const {
+    return 0;
+  }
+#endif
   template<class View>
   forceinline bool
   ConstView<View>::assigned(void) const {
@@ -473,6 +492,13 @@ namespace Gecode {
   VarImpView<Var>::afc(void) const {
     return x->afc();
   }
+#ifdef GECODE_HAS_CBS
+  template<class Var>
+  forceinline unsigned int
+  VarImpView<Var>::id(void) const {
+    return x->id();
+  }
+#endif
   template<class Var>
   forceinline bool
   VarImpView<Var>::assigned(void) const {
@@ -572,6 +598,13 @@ namespace Gecode {
   DerivedView<View>::afc(void) const {
     return x.afc();
   }
+#ifdef GECODE_HAS_CBS
+  template<class View>
+  forceinline unsigned int
+  DerivedView<View>::id(void) const {
+    return x.id();
+  }
+#endif
   template<class View>
   forceinline bool
   DerivedView<View>::assigned(void) const {

--- a/gecode/kernel/view.hpp
+++ b/gecode/kernel/view.hpp
@@ -3,8 +3,12 @@
  *  Main authors:
  *     Christian Schulte <schulte@gecode.org>
  *
+ *  Contributing authors:
+ *     Samuel Gagnon <samuel.gagnon92@gmail.com>
+ *
  *  Copyright:
  *     Christian Schulte, 2005
+ *     Samuel Gagnon, 2018
  *
  *  Last modified:
  *     $Date$ by $Author$


### PR DESCRIPTION
> With Gecode 5.1.0 we decided to revisit our design to make a much smaller and simpler patch (~130 lines, mostly boilerplate code) to support counting-based search. It offers three new functionalities:
>
> - A unique id for each variable that we can access from views
> - A method for translating a value to its non derived equivalent for derived views
>
> - Two new virtual methods inside the Propagator class. Counting-based search relies on specialized counting algorithms inside propagators. So far we implemented such algorithms for distinct, extensional, and linear constraints (not yet included in this patch).
>
> With those changes, it is possible to create a custom brancher in the user's model to use our heuristics.
>
> We are currently expanding our branchers and counting algorithms. The three commits above are the foundation of our work.

Like discussed, we added a flag (--enable-cbs) for triggering a conditional #ifdef called GECODE_HAS_CBS; all our code is now in this #ifdef. However, I did not run "make -f Makefile.contribs"
for generating the configure script as it seemed to add unrelated changes (i.e. a new --runstatedir option and changes related to qecode).

I've made sure our code does not add any warning when compiling with or without --enable-cbs. This is why, for example, the argument name in `VarImp<VIC>::VarImp(Space&)` is only added when we need it:

```
  VarImp<VIC>::VarImp(
#ifdef GECODE_HAS_CBS
  Space& home) : var_id(++home.var_id_counter) {
#else
  Space&) {
#endif
```

If you prefer a single commit, or want me to change anything, please let me know.

Thank you again for your time.