### PR TITLE
Changelog.in updated for counting-based search addition.

### DIFF
--- a/changelog.in
+++ b/changelog.in
@@ -9385,3 +9385,17 @@ Date:		2005-12-06
 [DESCRIPTION]
 Initial release.
 
+[ENTRY]
+Module: kernel
+What:   new
+Rank:   minor
+Thanks: Gilles Pesant and Samuel Gagnon
+[DESCRIPTION]
+Introduction of a basic structure for supporting counting-based
+search as described in:
+S. Gagnon, G. Pesant, Accelerating Counting-Based Search, CPAIOR 2018.
+This is only enabled if Gecode has been compiled with the option
+--enable-cbs.
+[MORE]
+A branching option will be added to compatible examples as
+counting algorithms are added to constraints.


### PR DESCRIPTION
Hi Christian,

Is there a way of creating an hyperlink (our link is rather long)? 
I see the following in changelog.in:

```
New example: the steel mill slab design problem (Problem 38 in <a
href="http://csplib.org">CSPLib</a>).
```

But it does not work: [Gecode 3.0.0 Changelog](http://www.gecode.org/doc-latest/reference/PageChange.html#SectionChanges_3_0_0)

Otherwise, I will include a link to our paper under `[MORE]`.

Thank you again for your time,

Samuel
