### PR TITLE
Small typo in examples/sudoku.cpp

### DIFF
--- a/examples/sudoku.cpp
+++ b/examples/sudoku.cpp
@@ -99,7 +99,7 @@ public:
   /// Perform copying during cloning
   virtual Space*
   copy(void) {
-    return new SudokuInt(*this);
+    return new Sudoku(*this);
   }
 
   /// Print solution


### PR DESCRIPTION
Hi Christian,

There was a small typo in the new Sudoku model that raised an error during compilation.

Samuel