### PR TITLE
Develop

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -214,6 +214,13 @@ else ()
   set(GECODE_THREADS_PTHREADS 1)
 endif ()
 
+option(ENABLE_GIST "Enable gist" OFF)
+if (ENABLE_GIST)
+  set(GECODE_USE_QT TRUE)
+else()
+  set(GECODE_USE_QT FALSE)
+endif()
+
 # Don't use Qt if GECODE_USE_QT is set to FALSE.
 if (NOT DEFINED GECODE_USE_QT OR GECODE_USE_QT)
   find_package(Qt5 QUIET COMPONENTS Core Gui Widgets PrintSupport)
@@ -387,6 +394,11 @@ foreach (lib support kernel search int set float
   endif ()
 endforeach ()
 
+option(ENABLE_CPPROFILER "Enable cpprofiler tracer mode" ON)
+if(ENABLE_CPPROFILER)
+  add_definitions(-DGECODE_HAS_CPPROFILER)
+endif()
+
 find_package(Threads)
 target_link_libraries(gecodesupport ${CMAKE_THREAD_LIBS_INIT})
 target_link_libraries(gecodekernel gecodesupport)
@@ -418,7 +430,7 @@ add_executable(gecode-test ${TESTSRC} ${TESTHDR})
 target_link_libraries(gecode-test gecodeflatzinc gecodeminimodel)
 
 add_executable(fzn-gecode ${FLATZINCEXESRC})
-target_link_libraries(fzn-gecode gecodeflatzinc gecodegist gecodeminimodel gecodedriver)
+target_link_libraries(fzn-gecode gecodeflatzinc gecodeminimodel gecodedriver)
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 

--- a/gecode/flatzinc/flatzinc.cpp
+++ b/gecode/flatzinc/flatzinc.cpp
@@ -1748,9 +1748,9 @@ namespace Gecode { namespace FlatZinc {
     getInfo(const Space& space) const {
       std::stringstream ss;
       if (const FlatZincSpace* fz_space = dynamic_cast<const FlatZincSpace*>(&space)) {
-        ss << "{domains = \"";
+        ss << "{\n\t\"domains\": \"";
         ss << fz_space->getDomains(p);
-        ss << "\"}";
+        ss << "\"\n}";
       }
       return ss.str();
     }


### PR DESCRIPTION
Added ENABLE_GIST option to CMakeFiles.txt to allow gist to be turned on and off.
Added ENABLE_CPPROFILER option to CMakeFiles.txt to enable the profiler tracer in fzn-gecode.
CPProfiler tracer FlatZincGetInfo class in flatzinc.cpp was producing malformed JSON, this should be fixed now.