### PR TITLE
Remove implicit fallthrough from linear expression to intersection

### DIFF
--- a/gecode/minimodel/set-expr.cpp
+++ b/gecode/minimodel/set-expr.cpp
@@ -378,6 +378,7 @@ namespace Gecode {
             rel(home,iv,srt,s,b);
           }
         }
+        break;
       case SetExpr::NT_INTER:
         {
           SetVarArgs bs(p+n);


### PR DESCRIPTION
The original code looked broken, and it's probably
possible to come up with a test case using minimodel
that posts more constraints than intended.