### PR TITLE
Add missing stdarg.h include used for variable argument lists

### DIFF
--- a/test/ldsb.cpp
+++ b/test/ldsb.cpp
@@ -38,6 +38,7 @@
 #ifdef GECODE_HAS_SET_VARS
 #include <gecode/set.hh>
 #include <gecode/set/branch.hh>
+#include <stdarg.h>
 #endif
 
 #include <gecode/minimodel.hh>


### PR DESCRIPTION
Without this header, make test fails on Linux with
GCC 8.2.1. Error included below.

	test/ldsb.cpp: In function ‘Gecode::IntSetArgs Test::LDSB::ISA(int, ...)’:
	test/ldsb.cpp:1311:5: error: ‘va_start’ was not declared in this scope
		  va_start(args, n);
		  ^~~~~~~~
	test/ldsb.cpp:1311:5: note: suggested alternative: ‘va_list’
		  va_start(args, n);
		  ^~~~~~~~
		  va_list
	test/ldsb.cpp:1315:27: error: expected primary-expression before ‘int’
			 int x = va_arg(args,int);
										^~~
	test/ldsb.cpp:1315:15: error: ‘va_arg’ was not declared in this scope
			 int x = va_arg(args,int);
						^~~~~~
	test/ldsb.cpp:1315:15: note: suggested alternative: ‘optarg’
			 int x = va_arg(args,int);
						^~~~~~
						optarg
	test/ldsb.cpp:1324:5: error: ‘va_end’ was not declared in this scope
		  va_end(args);
		  ^~~~~~
	test/ldsb.cpp:1324:5: note: suggested alternative: ‘rand’
		  va_end(args);
		  ^~~~~~
		  rand