### PR TITLE
CBSBrancher::dispose unnecessarily calls home.ignore(*this,AP_DISPOSE)

### DIFF
--- a/gecode/int/branch/cbs.hpp
+++ b/gecode/int/branch/cbs.hpp
@@ -89,7 +89,6 @@ namespace Gecode { namespace Int { namespace Branch {
   template<class View>
   forceinline size_t
   CBSBrancher<View>::dispose(Space& home) {
-    home.ignore(*this, AP_DISPOSE);
     (void) Brancher::dispose(home);
     return sizeof(*this);
   }


### PR DESCRIPTION
Hi Christian,

I noticed I forgot to remove this line in CBSBrancher; there's no corresponding `home.notice(*this,AP_DISPOSE)` in the constructor and I don't need to explicitly deallocate resources. It caused a crash while a was testing a new counting algorithm.

Thank you,

Samuel

EDIT: I changed my mind. As I am using a `SharedHandle` in my brancher, I do have to explicitly call the destructor of my SharedHandle in `CBSBrancher::dispose`. I will make another PR with the right correction.