### PR TITLE
Fix typo of #41

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -450,7 +450,7 @@ if(WIN32)
     ${PROJECT_BINARY_DIR}/tools/flatzinc/mzn-gecode.bat
     @ONLY
   )
-  set(MZN_SCRIPT ${PROJECT_BINARY_DIR}tools/flatzinc/mzn-gecode.bat)
+  set(MZN_SCRIPT ${PROJECT_BINARY_DIR}/tools/flatzinc/mzn-gecode.bat)
 else()
   configure_file(
     ${PROJECT_SOURCE_DIR}/tools/flatzinc/mzn-gecode.in


### PR DESCRIPTION
This commit fixes a simple typo that I made in the submission of #41. Without the separator in the path the install target will not work.

Sorry for the inconvenience, I didn't have access to a windows machine yesterday and assumed it worked. I've now tested the install target on a windows machine and it works with this fix.

I assume no additional changelog entry is necessary for this small fix