### PR TITLE
Enable half-reification for fzn-gecode

### DIFF
--- a/changelog.in
+++ b/changelog.in
@@ -69,6 +69,20 @@ Date: 2019-??-??
 Let's see.
 
 [ENTRY]
+Module: flatzinc
+What:   change
+Rank:   minor
+Thanks:	Jip J. Dekker
+[DESCRIPTION]
+Enable support for half-reified constraints in the Gecode MiniZinc
+library. Half-reified constraints are used when a MiniZinc 
+expression has to be reified and is detected to be in a positive
+context. If no Half-reified constraint has been made available by
+solver, the full reification will be used. Half-reifed constraints
+in the MiniZinc solver library are declared in the same way as
+reified constraints, but are appended by "_imp" instead of "_reif".
+
+[ENTRY]
 Module: kernel
 What:   bug
 Rank:   major

--- a/gecode/flatzinc/mznlib/count.mzn
+++ b/gecode/flatzinc/mznlib/count.mzn
@@ -34,3 +34,6 @@ predicate count(array[int] of var int: x, var int: y, var int: c);
 
 predicate count_reif(array[int] of var int: x, var int: y, var int: c,
                      var bool: b);
+
+predicate count_imp(array[int] of var int: x, var int: y, var int: c,
+                    var bool: r);

--- a/gecode/flatzinc/mznlib/redefinitions.mzn
+++ b/gecode/flatzinc/mznlib/redefinitions.mzn
@@ -89,3 +89,54 @@ predicate int_pow(var int: x, var int: y, var int: z) =
           [pow(pow_x[i],i) | i in lb(y)..ub(y)]);
     } in z=pow_table[y]
     endif;
+
+predicate array_bool_and_imp(array [int] of var bool: as, var bool: r);
+predicate array_bool_or_imp(array [int] of var bool: as, var bool: r);
+predicate array_bool_xor_imp(array [int] of var bool: as, var bool: r);
+
+predicate bool_and_imp(var bool: a, var bool: b, var bool: r);
+predicate bool_clause_imp(array [int] of var bool: as,
+                          array [int] of var bool: bs, var bool: r);
+predicate bool_ge_imp(var bool: a, var bool: b, var bool: r);
+predicate bool_gt_imp(var bool: a, var bool: b, var bool: r);
+predicate bool_le_imp(var bool: a, var bool: b, var bool: r);
+predicate bool_lt_imp(var bool: a, var bool: b, var bool: r);
+predicate bool_ne_imp(var bool: a, var bool: b, var bool: r);
+predicate bool_ne_imp(var bool: a, var bool: b, var bool: r);
+predicate bool_or_imp(var bool: a, var bool: b, var bool: r);
+predicate bool_xor_imp(var bool: a, var bool: b, var bool: r);
+
+predicate bool_lin_eq_imp(array [int] of int: as, array [int] of var bool: bs,
+                          var int: c, var bool: r);
+predicate bool_lin_ge_imp(array [int] of int: as, array [int] of var bool: bs,
+                          var int: c, var bool: r);
+predicate bool_lin_gt_imp(array [int] of int: as, array [int] of var bool: bs,
+                          var int: c, var bool: r);
+predicate bool_lin_le_imp(array [int] of int: as, array [int] of var bool: bs,
+                          var int: c, var bool: r);
+predicate bool_lin_lt_imp(array [int] of int: as, array [int] of var bool: bs,
+                          var int: c, var bool: r);
+predicate bool_lin_ne_imp(array [int] of int: as, array [int] of var bool: bs,
+                          var int: c, var bool: r);
+
+predicate int_eq_imp(var int: a, var int: b, var bool: r);
+predicate int_ge_imp(var int: a, var int: b, var bool: r);
+predicate int_gt_imp(var int: a, var int: b, var bool: r);
+predicate int_le_imp(var int: a, var int: b, var bool: r);
+predicate int_lt_imp(var int: a, var int: b, var bool: r);
+predicate int_ne_imp(var int: a, var int: b, var bool: r);
+
+predicate int_lin_eq_imp(array [int] of int: as, array [int] of var int: bs,
+                         int: c, var bool: r);
+predicate int_lin_ge_imp(array [int] of int: as, array [int] of var int: bs,
+                         int: c, var bool: r);
+predicate int_lin_gt_imp(array [int] of int: as, array [int] of var int: bs,
+                         int: c, var bool: r);
+predicate int_lin_le_imp(array [int] of int: as, array [int] of var int: bs,
+                         int: c, var bool: r);
+predicate int_lin_lt_imp(array [int] of int: as, array [int] of var int: bs,
+                         int: c, var bool: r);
+predicate int_lin_ne_imp(array [int] of int: as, array [int] of var int: bs,
+                         int: c, var bool: r);
+
+predicate set_in_imp(var int: x, set of int: S, var bool: r);


### PR DESCRIPTION
This PR will enable the use of half-reifications within fzn-gecode. Upcoming releases of MiniZinc will detect possible opportunities to use half-reification instead of a full-reification. The half-reifications will only be used if made available by the solver. Since Gecode supports many half-reified FlatZinc primitives, these additions to the Gecode MiniZinc library will signal MiniZinc that the half-reified version are available for use.

The usage of these constraints has been tested using the development version of MiniZinc and the MiniZinc benchmarks suite and no errors were found. 