### PR TITLE
Feature: better flatzinc errors

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+# EditorConfig file for Gecode
+# See https://EditorConfig.org for more information about the .editorconfig format
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+indent_style = space
+indent_size = 2
+
+# Makefiles need to use Tab indentation
+[Makefile*]
+indent_style = tab

--- a/changelog.in
+++ b/changelog.in
@@ -70,6 +70,16 @@ Let's see.
 
 [ENTRY]
 Module: flatzinc
+What:   new
+Rank:   minor
+[DESCRIPTION]
+Add MiniZinc constraint names to FlatZinc errors when applicable and available.
+[MORE]
+A constraint name is specified in MiniZinc using a string annotation "my name" on the constraint item,
+and is translated into FlatZinc using the mzn_constraint_name("my name").
+
+[ENTRY]
+Module: flatzinc
 What:   bug
 Rank:   minor
 [DESCRIPTION]

--- a/gecode/flatzinc/flatzinc.cpp
+++ b/gecode/flatzinc/flatzinc.cpp
@@ -766,7 +766,7 @@ namespace Gecode { namespace FlatZinc {
     typedef std::unordered_set<DFA> DFASet;
     /// Hash table of DFAs
     DFASet dfaSet;
-    
+
     /// Initialize
     FlatZincSpaceInitData(void) {}
   };
@@ -1010,9 +1010,9 @@ namespace Gecode { namespace FlatZinc {
       try {
         registry().post(*this, ce);
       } catch (Gecode::Exception& e) {
-        throw FlatZinc::Error("Gecode", e.what());
+          throw FlatZinc::Error("Gecode", e.what(), ce.ann);
       } catch (AST::TypeError& e) {
-        throw FlatZinc::Error("Type error", e.what());
+          throw FlatZinc::Error("Type error", e.what(), ce.ann);
       }
       delete ces[i];
       ces[i] = nullptr;
@@ -1494,7 +1494,7 @@ namespace Gecode { namespace FlatZinc {
       branch(bg(*this), sv_sol, def_set_varsel, def_set_valsel, nullptr,
              &varValPrint<SetVar>);
       branchInfo.add(bg,def_set_rel_left,def_set_rel_right,sv_sol_names);
-      
+
     }
 #endif
     iv_aux = IntVarArray(*this, iv_tmp);
@@ -1905,7 +1905,7 @@ namespace Gecode { namespace FlatZinc {
         double initTime = totalTime - solveTime;
         out << std::endl
             << "%%%mzn-stat: initTime=" << initTime
-            << std::endl;      
+            << std::endl;
         out << "%%%mzn-stat: solveTime=" << solveTime
             << std::endl;
         out << "%%%mzn-stat: solutions="
@@ -2151,8 +2151,8 @@ namespace Gecode { namespace FlatZinc {
       }
       _initData->tupleSetSet.insert(ts);
     }
-    
-    
+
+
     return ts;
   }
   IntSharedArray
@@ -2166,7 +2166,7 @@ namespace Gecode { namespace FlatZinc {
       }
       _initData->intSharedArraySet.insert(sia);
     }
-    
+
     return sia;
   }
   IntArgs
@@ -2190,7 +2190,7 @@ namespace Gecode { namespace FlatZinc {
       }
       _initData->intSharedArraySet.insert(sia);
     }
-    
+
     return sia;
   }
   IntSet

--- a/gecode/flatzinc/registry.cpp
+++ b/gecode/flatzinc/registry.cpp
@@ -60,7 +60,7 @@ namespace Gecode { namespace FlatZinc {
     std::map<std::string,poster>::iterator i = r.find(ce.id);
     if (i == r.end()) {
       throw FlatZinc::Error("Registry",
-        std::string("Constraint ")+ce.id+" not found");
+        std::string("Constraint ")+ce.id+" not found", ce.ann);
     }
     i->second(s, ce, ce.ann);
   }
@@ -464,7 +464,7 @@ namespace Gecode { namespace FlatZinc {
       IntVar x0 = s.arg2IntVar(ce[0]);
       IntVar x2 = s.arg2IntVar(ce[2]);
       pow(s, x0, ce[1]->getInt(), x2, s.ann2ipl(ann));
-    }    
+    }
     void p_int_div(FlatZincSpace& s, const ConExpr& ce, AST::Node* ann) {
       IntVar x0 = s.arg2IntVar(ce[0]);
       IntVar x1 = s.arg2IntVar(ce[1]);
@@ -1041,7 +1041,7 @@ namespace Gecode { namespace FlatZinc {
 
     void p_maximum_arg_bool(FlatZincSpace& s, const ConExpr& ce, AST::Node* ann) {
       BoolVarArgs bv = s.arg2boolvarargs(ce[0]);
-      int offset = ce[1]->getInt();      
+      int offset = ce[1]->getInt();
       argmax(s, bv, offset, s.arg2IntVar(ce[2]), true, s.ann2ipl(ann));
     }
 
@@ -1171,7 +1171,7 @@ namespace Gecode { namespace FlatZinc {
       TupleSet ts = s.arg2tupleset(tuples,x.size());
       extensional(s,x,ts,Reify(s.arg2BoolVar(ce[2]),RM_IMP),s.ann2ipl(ann));
     }
-    
+
     void
     p_table_bool(FlatZincSpace& s, const ConExpr& ce, AST::Node* ann) {
       BoolVarArgs x = s.arg2boolvarargs(ce[0]);

--- a/misc/gentxtchangelog.perl
+++ b/misc/gentxtchangelog.perl
@@ -4,9 +4,13 @@
 #     Christian Schulte <schulte@gecode.org>
 #     Guido Tack <tack@gecode.org>
 #
+#  Contributing authors:
+#     Mikael Lagerkvist <lagerkvist@gecode.org>
+#
 #  Copyright:
 #     Christian Schulte, 2005
 #     Guido Tack, 2006
+#     Mikael Lagerkvist, 2020
 #
 #  This file is part of Gecode, the generic constraint
 #  development environment:
@@ -63,6 +67,7 @@ $modclear{"support"} = "Support algorithms and datastructures";
 $modclear{"example"} = "Example scripts";
 $modclear{"test"} = "Systematic tests";
 $modclear{"gist"} = "Gist";
+$modclear{"flatzinc"} = "Gecode/FlatZinc";
 $modclear{"other"} = "General";
 
 $whatclear{"bug"} = "Bug fixes";
@@ -76,7 +81,7 @@ $rankclear{"minor"} = "minor";
 $rankclear{"major"} = "major";
 
 @modorder = ("kernel","search","int","set","cpltset","scheduling","minimodel",
-	     "iter","support","example","test","gist","other");
+	     "iter","support","example","test","gist","flatzinc","other");
 
 @whatorder = ("new","change","bug","performance","documentation");
 


### PR DESCRIPTION
This adds slightly better error messages in flat-zinc when there are constraint names in the MiniZinc file. 

An error that was previously reported as

    Error: Gecode: Float::linear: Number out of limits

will now (given that the constraint the error originates from has been
annotated in the MiniZinc file) be reported as

    Error: Gecode: Float::linear: Number out of limits in constraint "my constraint name"

Also, adds an .editorconfig file, to ensure consistent spacing for many different editors.