### PR TITLE
Make elements and weights in OverweightValues non-const

### DIFF
--- a/gecode/set/int/weights.hpp
+++ b/gecode/set/int/weights.hpp
@@ -49,9 +49,9 @@ namespace Gecode { namespace Set { namespace Int {
     /// The value iterator
     I iter;
     /// A superset of the elements found in the iterator
-    const SharedArray<int> elements;
+    SharedArray<int> elements;
     /// Weights for all the possible elements
-    const SharedArray<int> weights;
+    SharedArray<int> weights;
     /// The current index into the elements and weights
     int index;
     /// Move to the next element


### PR DESCRIPTION
Having `elements` and `weights` tagged const means that `OverweightValues::init` cannot assign to them. This causes compilation to fail for emscripten (even though this is never used - not sure why emscripten complains about this but normal compilers don't).

Fixes #67.