### PR TITLE
Avoid reserved identifier names

### DIFF
--- a/changelog.in
+++ b/changelog.in
@@ -85,19 +85,27 @@ Rank:   minor
 Issue:  63
 Thanks: Markus Elfring
 [DESCRIPTION]
+Remove usages of reserved identifiers such as __GECODE_KERNEL_HH__ and
+_View.
+[MORE]
 Gecode used to use include guards of the form __GECODE_KERNEL_HH__.
 Using a double underscore in an identifier is reserved, and thus
 undefined behaviour. Use guards of the form GECODE_KERNEL_HH instead.
-
+Similarly, names with a single leading underscore followed by a
+capital letter are also reserved, and usage is thus undefined
+behaviour, and are removed.
+	
 [ENTRY]
 Module: flatzinc
 What:   new
 Rank:   minor
 [DESCRIPTION]
-Add MiniZinc constraint names to FlatZinc errors when applicable and available.
+Add MiniZinc constraint names to FlatZinc errors when applicable and
+available.
 [MORE]
-A constraint name is specified in MiniZinc using a string annotation "my name" on the constraint item,
-and is translated into FlatZinc using the mzn_constraint_name("my name").
+A constraint name is specified in MiniZinc using a string annotation
+"my name" on the constraint item, and is translated into FlatZinc
+using the mzn_constraint_name("my name").
 
 [ENTRY]
 Module: flatzinc

--- a/gecode/driver.hh
+++ b/gecode/driver.hh
@@ -646,7 +646,7 @@ namespace Gecode {
 
 #ifdef GECODE_HAS_GIST
     /// Helper class storing Gist inspectors
-    class _I {
+    class I_ {
     private:
       /// The double click inspectors
       Support::DynamicArray<Gist::Inspector*,Heap> _click;
@@ -666,7 +666,7 @@ namespace Gecode {
       unsigned int n_compare;
     public:
       /// Constructor
-      _I(void);
+      I_(void);
       /// Add inspector that reacts on node double clicks
       void click(Gist::Inspector* i);
       /// Add inspector that reacts on each new solution that is found

--- a/gecode/driver/options.hpp
+++ b/gecode/driver/options.hpp
@@ -557,40 +557,40 @@ namespace Gecode {
 
 #ifdef GECODE_HAS_GIST
   forceinline
-  Options::_I::_I(void) : _click(heap,1), n_click(0),
+  Options::I_::I_(void) : _click(heap,1), n_click(0),
     _solution(heap,1), n_solution(0), _move(heap,1), n_move(0),
     _compare(heap,1), n_compare(0) {}
 
   forceinline void
-  Options::_I::click(Gist::Inspector* i) {
+  Options::I_::click(Gist::Inspector* i) {
     _click[static_cast<int>(n_click++)] = i;
   }
   forceinline void
-  Options::_I::solution(Gist::Inspector* i) {
+  Options::I_::solution(Gist::Inspector* i) {
     _solution[static_cast<int>(n_solution++)] = i;
   }
   forceinline void
-  Options::_I::move(Gist::Inspector* i) {
+  Options::I_::move(Gist::Inspector* i) {
     _move[static_cast<int>(n_move++)] = i;
   }
   forceinline void
-  Options::_I::compare(Gist::Comparator* i) {
+  Options::I_::compare(Gist::Comparator* i) {
     _compare[static_cast<int>(n_compare++)] = i;
   }
   forceinline Gist::Inspector*
-  Options::_I::click(unsigned int i) const {
+  Options::I_::click(unsigned int i) const {
     return (i < n_click) ? _click[i] : nullptr;
   }
   forceinline Gist::Inspector*
-  Options::_I::solution(unsigned int i) const {
+  Options::I_::solution(unsigned int i) const {
     return (i < n_solution) ? _solution[i] : nullptr;
   }
   forceinline Gist::Inspector*
-  Options::_I::move(unsigned int i) const {
+  Options::I_::move(unsigned int i) const {
     return (i < n_move) ? _move[i] : nullptr;
   }
   forceinline Gist::Comparator*
-  Options::_I::compare(unsigned int i) const {
+  Options::I_::compare(unsigned int i) const {
     return (i < n_compare) ? _compare[i] : nullptr;
   }
 #endif

--- a/gecode/flatzinc/option.hh
+++ b/gecode/flatzinc/option.hh
@@ -31,8 +31,8 @@
  *
  */
 
-#ifndef __FLATZINC_OPTION_HH__
-#define __FLATZINC_OPTION_HH__
+#ifndef FLATZINC_OPTION_HH
+#define FLATZINC_OPTION_HH
 
 namespace Gecode { namespace FlatZinc {
 

--- a/gecode/flatzinc/parser.hh
+++ b/gecode/flatzinc/parser.hh
@@ -31,8 +31,8 @@
  *
  */
 
-#ifndef __FLATZINC_PARSER_HH__
-#define __FLATZINC_PARSER_HH__
+#ifndef FLATZINC_PARSER_HH
+#define FLATZINC_PARSER_HH
 
 #include <gecode/flatzinc.hh>
 

--- a/gecode/flatzinc/varspec.hh
+++ b/gecode/flatzinc/varspec.hh
@@ -31,8 +31,8 @@
  *
  */
 
-#ifndef GECODE_FLATZINC_VARSPEC__HH
-#define GECODE_FLATZINC_VARSPEC__HH
+#ifndef GECODE_FLATZINC_VARSPEC_HH
+#define GECODE_FLATZINC_VARSPEC_HH
 
 #include <gecode/flatzinc/option.hh>
 #include <gecode/flatzinc/ast.hh>

--- a/gecode/float/trigonometric/sincos.hpp
+++ b/gecode/float/trigonometric/sincos.hpp
@@ -40,11 +40,11 @@ namespace Gecode { namespace Float { namespace Trigonometric {
    */
 template<class V>
 void aSinProject(Rounding& r, const V& aSinIv, FloatNum& iv_min, FloatNum& iv_max, int& n_min, int& n_max) {
-  #define I0__PI_2I    FloatVal(0,pi_half_upper())
-  #define IPI_2__PII   FloatVal(pi_half_lower(),pi_upper())
-  #define IPI__3PI_2I  FloatVal(pi_lower(),3*pi_half_upper())
-  #define I3PI_2__2PII FloatVal(3*pi_half_lower(),pi_twice_upper())
-  #define POS(X) ((I0__PI_2I.in(X))?0: (IPI_2__PII.in(X))?1: (IPI__3PI_2I.in(X))?2: 3 )
+  #define I0_PI_2I    FloatVal(0,pi_half_upper())
+  #define IPI_2_PII   FloatVal(pi_half_lower(),pi_upper())
+  #define IPI_3PI_2I  FloatVal(pi_lower(),3*pi_half_upper())
+  #define I3PI_2_2PII FloatVal(3*pi_half_lower(),pi_twice_upper())
+  #define POS(X) ((I0_PI_2I.in(X))?0: (IPI_2_PII.in(X))?1: (IPI_3PI_2I.in(X))?2: 3 )
   #define ASININF_DOWN r.asin_down(aSinIv.min())
   #define ASINSUP_UP r.asin_up(aSinIv.max())
 
@@ -104,10 +104,10 @@ void aSinProject(Rounding& r, const V& aSinIv, FloatNum& iv_min, FloatNum& iv_ma
   #undef ASININF_DOWN
   #undef ASINSUP_UP
   #undef POS
-  #undef I0__PI_2I
-  #undef IPI_2__PII
-  #undef IPI__3PI_2I
-  #undef I3PI_2__2PII
+  #undef I0_PI_2I
+  #undef IPI_2_PII
+  #undef IPI_3PI_2I
+  #undef I3PI_2_2PII
 }
 
 /*

--- a/gecode/float/trigonometric/tanatan.hpp
+++ b/gecode/float/trigonometric/tanatan.hpp
@@ -39,8 +39,8 @@ namespace Gecode { namespace Float { namespace Trigonometric {
   template<class V>
   void
   aTanProject(Rounding& r, const V& aTanIv, FloatNum& iv_min, FloatNum& iv_max, int& n_min, int& n_max) {
-    #define I0__PI_2I    FloatVal(0,pi_half_upper())
-    #define POS(X) ((I0__PI_2I.in(X))?0:1)
+    #define I0_PI_2I    FloatVal(0,pi_half_upper())
+    #define POS(X) ((I0_PI_2I.in(X))?0:1)
     #define ATANINF_DOWN r.atan_down(aTanIv.min())
     #define ATANSUP_UP   r.atan_up(aTanIv.max())
 
@@ -80,7 +80,7 @@ namespace Gecode { namespace Float { namespace Trigonometric {
     #undef ATANINF_DOWN
     #undef ATANSUP_UP
     #undef POS
-    #undef I0__PI_2I
+    #undef I0_PI_2I
   }
 
   /*
@@ -96,10 +96,10 @@ namespace Gecode { namespace Float { namespace Trigonometric {
     int n_max = static_cast<int>(r.div_up(x0.max() + pi_half_upper(), pi_upper()));
 
     if (x0 == x1) {
-      #define I0__PI_2I    FloatVal(0,pi_half_upper())
-      if (I0__PI_2I.in(x0.max()))  GECODE_ME_CHECK(x0.lq(home,0));
-      if (I0__PI_2I.in(-x0.min())) GECODE_ME_CHECK(x0.gq(home,0));
-      #undef I0__PI_2I
+      #define I0_PI_2I    FloatVal(0,pi_half_upper())
+      if (I0_PI_2I.in(x0.max()))  GECODE_ME_CHECK(x0.lq(home, 0));
+      if (I0_PI_2I.in(-x0.min())) GECODE_ME_CHECK(x0.gq(home, 0));
+      #undef I0_PI_2I
 
       n_min = static_cast<int>(r.div_up(x0.min(), pi_upper()));
       n_max = static_cast<int>(r.div_up(x0.max(), pi_upper()));
@@ -150,10 +150,10 @@ namespace Gecode { namespace Float { namespace Trigonometric {
   ExecStatus
   Tan<A,B>::post(Home home, A x0, B x1) {
     if (x0 == x1) {
-      #define I0__PI_2I    FloatVal(0,pi_half_upper())
-      if (I0__PI_2I.in(x0.max()))  GECODE_ME_CHECK(x0.lq(home,0));
-      if (I0__PI_2I.in(-x0.min())) GECODE_ME_CHECK(x0.gq(home,0));
-      #undef I0__PI_2I
+      #define I0_PI_2I    FloatVal(0,pi_half_upper())
+      if (I0_PI_2I.in(x0.max()))  GECODE_ME_CHECK(x0.lq(home, 0));
+      if (I0_PI_2I.in(-x0.min())) GECODE_ME_CHECK(x0.gq(home, 0));
+      #undef I0_PI_2I
     }
     GECODE_ES_CHECK(dopropagate(home,x0,x1));
     (void) new (home) Tan<A,B>(home,x0,x1);

--- a/gecode/gist.hh
+++ b/gecode/gist.hh
@@ -234,7 +234,7 @@ namespace Gecode {
     class Options : public Search::Options {
     public:
       /// Helper class storing inspectors
-      class _I {
+      class I_ {
       private:
         Support::DynamicArray<Inspector*,Heap> _click;
         unsigned int n_click;
@@ -246,7 +246,7 @@ namespace Gecode {
         unsigned int n_compare;
       public:
         /// Constructor
-        _I(void);
+        I_(void);
         /// Add inspector that reacts on node double clicks
         void click(Inspector* i);
         /// Add inspector that reacts on each new solution that is found

--- a/gecode/gist/gecodelogo.hh
+++ b/gecode/gist/gecodelogo.hh
@@ -31,8 +31,8 @@
  *
  */
 
-#ifndef __GECODE_GIST_GECODELOGO_HH_
-#define __GECODE_GIST_GECODELOGO_HH_
+#ifndef GECODE_GIST_GECODELOGO_HH
+#define GECODE_GIST_GECODELOGO_HH
 
 namespace Gecode { namespace Gist {
 

--- a/gecode/gist/gist.hpp
+++ b/gecode/gist/gist.hpp
@@ -162,40 +162,40 @@ namespace Gecode { namespace Gist {
   Options::Options(void) {}
 
   forceinline
-  Options::_I::_I(void) : _click(heap,1), n_click(0),
+  Options::I_::I_(void) : _click(heap,1), n_click(0),
     _solution(heap,1), n_solution(0),
     _move(heap,1), n_move(0), _compare(heap,1), n_compare(0) {}
 
   forceinline void
-  Options::_I::click(Inspector* i) {
+  Options::I_::click(Inspector* i) {
     _click[static_cast<int>(n_click++)] = i;
   }
   forceinline void
-  Options::_I::solution(Inspector* i) {
+  Options::I_::solution(Inspector* i) {
     _solution[static_cast<int>(n_solution++)] = i;
   }
   forceinline void
-  Options::_I::move(Inspector* i) {
+  Options::I_::move(Inspector* i) {
     _move[static_cast<int>(n_move++)] = i;
   }
   forceinline void
-  Options::_I::compare(Comparator* c) {
+  Options::I_::compare(Comparator* c) {
     _compare[static_cast<int>(n_compare++)] = c;
   }
   forceinline Inspector*
-  Options::_I::click(unsigned int i) const {
+  Options::I_::click(unsigned int i) const {
     return (i < n_click) ? _click[i] : nullptr;
   }
   forceinline Inspector*
-  Options::_I::solution(unsigned int i) const {
+  Options::I_::solution(unsigned int i) const {
     return (i < n_solution) ? _solution[i] : nullptr;
   }
   forceinline Inspector*
-  Options::_I::move(unsigned int i) const {
+  Options::I_::move(unsigned int i) const {
     return (i < n_move) ? _move[i] : nullptr;
   }
   forceinline Comparator*
-  Options::_I::compare(unsigned int i) const {
+  Options::I_::compare(unsigned int i) const {
     return (i < n_compare) ? _compare[i] : nullptr;
   }
 

--- a/gecode/int.hh
+++ b/gecode/int.hh
@@ -193,7 +193,7 @@ namespace Gecode {
       /// Check whether \a n is included in the set
       GECODE_INT_EXPORT bool in(int n) const;
       /// Perform equality test on ranges
-      GECODE_INT_EXPORT bool equal(const IntSetObject& so) const; 
+      GECODE_INT_EXPORT bool equal(const IntSetObject& so) const;
       /// Delete object
       GECODE_INT_EXPORT virtual ~IntSetObject(void);
     };
@@ -232,7 +232,7 @@ namespace Gecode {
     template<class I>
     explicit IntSet(const I& i);
     /// Initialize with integers from list \a r
-    GECODE_INT_EXPORT 
+    GECODE_INT_EXPORT
     explicit IntSet(std::initializer_list<int> r);
     /** \brief Initialize with ranges from vector \a r
      *
@@ -981,7 +981,7 @@ namespace Gecode {
     IPL_BASIC = 4,    ///< Use basic propagation algorithm
     IPL_ADVANCED = 8, ///< Use advanced propagation algorithm
     IPL_BASIC_ADVANCED = IPL_BASIC | IPL_ADVANCED, ///< Use both
-    _IPL_BITS = 4 ///< Number of bits required (internal)
+    IPL_BITS_ = 4 ///< Number of bits required (internal)
   };
 
   /// Extract value, bounds, or domain propagation from propagation level
@@ -4194,7 +4194,7 @@ namespace Gecode {
    *
    * \ingroup TaskModelIntBranch
    */
-  typedef std::function<double(const Space& home, IntVar x, int i)> 
+  typedef std::function<double(const Space& home, IntVar x, int i)>
     IntBranchMerit;
   /**
    * \brief Branch merit function type for Boolean variables

--- a/gecode/kernel/branch/merit.hpp
+++ b/gecode/kernel/branch/merit.hpp
@@ -42,15 +42,15 @@ namespace Gecode {
   /**
    * \brief Base-class for merit class
    */
-  template<class _View, class _Val>
+  template<class View_, class Val_>
   class MeritBase {
   public:
     /// View type
-    typedef _View View;
+    typedef View_ View;
     /// Corresponding variable type
     typedef typename View::VarType Var;
     /// Type of merit
-    typedef _Val Val;
+    typedef Val_ Val;
     /// Constructor for initialization
     MeritBase(Space& home, const VarBranch<Var>& vb);
     /// Constructor for cloning

--- a/gecode/kernel/branch/val-commit.hpp
+++ b/gecode/kernel/branch/val-commit.hpp
@@ -40,15 +40,15 @@ namespace Gecode {
    */
   //@{
   /// Base class for value commit
-  template<class _View, class _Val>
+  template<class View_, class Val_>
   class ValCommit {
   public:
     /// View type
-    typedef _View View;
+    typedef View_ View;
     /// Corresponding variable type
     typedef typename View::VarType Var;
     /// Value type
-    typedef _Val Val;
+    typedef Val_ Val;
   public:
     /// Constructor for initialization
     ValCommit(Space& home, const ValBranch<Var>& vb);

--- a/gecode/kernel/branch/val-sel-commit.hpp
+++ b/gecode/kernel/branch/val-sel-commit.hpp
@@ -40,15 +40,15 @@ namespace Gecode {
    */
   //@{
   /// Base class for value selection and commit
-  template<class _View, class _Val>
+  template<class View_, class Val_>
   class ValSelCommitBase {
   public:
     /// View type
-    typedef _View View;
+    typedef View_ View;
     /// Corresponding variable type
     typedef typename View::VarType Var;
     /// Value type
-    typedef _Val Val;
+    typedef Val_ Val;
   public:
     /// Constructor for initialization
     ValSelCommitBase(Space& home, const ValBranch<Var>& vb);
@@ -128,7 +128,7 @@ namespace Gecode {
 
   template<class View, class Val>
   forceinline
-  ValSelCommitBase<View,Val>::ValSelCommitBase(Space&, 
+  ValSelCommitBase<View,Val>::ValSelCommitBase(Space&,
                                                const ValBranch<Var>&) {}
   template<class View, class Val>
   forceinline

--- a/gecode/kernel/branch/val-sel.hpp
+++ b/gecode/kernel/branch/val-sel.hpp
@@ -40,15 +40,15 @@ namespace Gecode {
    */
   //@{
   /// Base class for value selection
-  template<class _View, class _Val>
+  template<class View_, class Val_>
   class ValSel {
   public:
     /// View type
-    typedef _View View;
+    typedef View_ View;
     /// Corresponding variable type
     typedef typename View::VarType Var;
     /// Value type
-    typedef _Val Val;
+    typedef Val_ Val;
   public:
     /// Constructor for initialization
     ValSel(Space& home, const ValBranch<Var>& vb);

--- a/gecode/kernel/branch/view-sel.hpp
+++ b/gecode/kernel/branch/view-sel.hpp
@@ -40,11 +40,11 @@ namespace Gecode {
    */
   //@{
   /// Abstract class for view selection
-  template<class _View>
+  template<class View_>
   class ViewSel {
   public:
     /// Define the view type
-    typedef _View View;
+    typedef View_ View;
     /// The corresponding variable type
     typedef typename View::VarType Var;
     /// \name Initialization

--- a/gecode/kernel/core.cpp
+++ b/gecode/kernel/core.cpp
@@ -307,10 +307,10 @@ namespace Gecode {
           } while (--pc.p.active >= &pc.p.queue[0]);
           assert(pc.p.active < &pc.p.queue[0]);
           goto f_stable;
-        case __ES_SUBSUMED:
+        case ES_SUBSUMED_:
           p->unlink(); rfree(p,p->u.size);
           goto f_stable_or_unstable;
-        case __ES_PARTIAL:
+        case ES_PARTIAL_:
           // Schedule propagator with specified propagator events
           assert(p->u.med != 0);
           enqueue(p);
@@ -370,10 +370,10 @@ namespace Gecode {
           } while (--pc.p.active >= &pc.p.queue[0]);
           assert(pc.p.active < &pc.p.queue[0]);
           goto d_stable;
-        case __ES_SUBSUMED:
+        case ES_SUBSUMED_:
           p->unlink(); rfree(p,p->u.size);
           goto d_stable_or_unstable;
-        case __ES_PARTIAL:
+        case ES_PARTIAL_:
           // Schedule propagator with specified propagator events
           assert(p->u.med != 0);
           enqueue(p);
@@ -451,11 +451,11 @@ namespace Gecode {
           } while (--pc.p.active >= &pc.p.queue[0]);
           assert(pc.p.active < &pc.p.queue[0]);
           goto t_stable;
-        case __ES_SUBSUMED:
+        case ES_SUBSUMED_:
           GECODE_STATUS_TRACE(nullptr,SUBSUMED);
           p->unlink(); rfree(p,p->u.size);
           goto t_stable_or_unstable;
-        case __ES_PARTIAL:
+        case ES_PARTIAL_:
           GECODE_STATUS_TRACE(p,NOFIX);
           // Schedule propagator with specified propagator events
           assert(p->u.med != 0);
@@ -524,7 +524,7 @@ namespace Gecode {
       switch (top->propagate(*this,top_med_o)) {
       case ES_FIX:
         break;
-      case __ES_SUBSUMED:
+      case ES_SUBSUMED_:
         break;
       default:
         GECODE_NEVER;

--- a/gecode/kernel/core.hpp
+++ b/gecode/kernel/core.hpp
@@ -470,13 +470,13 @@ namespace Gecode {
    * \ingroup TaskActor
    */
   enum ExecStatus {
-    __ES_SUBSUMED       = -2, ///< Internal: propagator is subsumed, do not use
+    ES_SUBSUMED_       = -2, ///< Internal: propagator is subsumed, do not use
     ES_FAILED           = -1, ///< Execution has resulted in failure
     ES_NOFIX            =  0, ///< Propagation has not computed fixpoint
     ES_OK               =  0, ///< Execution is okay
     ES_FIX              =  1, ///< Propagation has computed fixpoint
     ES_NOFIX_FORCE      =  2, ///< Advisor forces rescheduling of propagator
-    __ES_PARTIAL        =  2  ///< Internal: propagator has computed partial fixpoint, do not use
+    ES_PARTIAL_        =  2  ///< Internal: propagator has computed partial fixpoint, do not use
   };
 
   /**
@@ -1027,7 +1027,7 @@ namespace Gecode {
     /// Return alternative
     unsigned int alternative(void) const;
   };
- 
+
   /**
    * \brief Post trace information
    */
@@ -3563,27 +3563,27 @@ namespace Gecode {
   forceinline ExecStatus
   Space::ES_SUBSUMED_DISPOSED(Propagator& p, size_t s) {
     p.u.size = s;
-    return __ES_SUBSUMED;
+    return ES_SUBSUMED_;
   }
 
   forceinline ExecStatus
   Space::ES_SUBSUMED(Propagator& p) {
     p.u.size = p.dispose(*this);
-    return __ES_SUBSUMED;
+    return ES_SUBSUMED_;
   }
 
   forceinline ExecStatus
   Space::ES_FIX_PARTIAL(Propagator& p, const ModEventDelta& med) {
     p.u.med = med;
     assert(p.u.med != 0);
-    return __ES_PARTIAL;
+    return ES_PARTIAL_;
   }
 
   forceinline ExecStatus
   Space::ES_NOFIX_PARTIAL(Propagator& p, const ModEventDelta& med) {
     p.u.med = AllVarConf::med_combine(p.u.med,med);
     assert(p.u.med != 0);
-    return __ES_PARTIAL;
+    return ES_PARTIAL_;
   }
 
 
@@ -4550,7 +4550,7 @@ namespace Gecode {
       case ES_NOFIX_FORCE:
         schedule(home,p,me,true);
         break;
-      case __ES_SUBSUMED:
+      case ES_SUBSUMED_:
       default:
         GECODE_NEVER;
       }
@@ -4587,7 +4587,7 @@ namespace Gecode {
   template<class VIC>
   ModEvent
   VarImp<VIC>::fail(Space& home) {
-    _fail(home); 
+    _fail(home);
     return ME_GEN_FAILED;
   }
 
@@ -4604,8 +4604,8 @@ namespace Gecode {
 
     unsigned int np =
       static_cast<unsigned int>(x->actorNonZero(pc_max+1) - x->actor(0));
-    unsigned int na = 
-      static_cast<unsigned int >(x->b.base + x->entries - 
+    unsigned int na =
+      static_cast<unsigned int >(x->b.base + x->entries -
                                  x->actorNonZero(pc_max+1));
     unsigned int n  = na + np;
     assert(n == x->degree());
@@ -4620,7 +4620,7 @@ namespace Gecode {
       ActorLink* p3 = f[3]->prev();
       ActorLink* p0 = f[0]->prev();
       ActorLink* p1 = f[1]->prev();
-      ActorLink* p2 = f[2]->prev(); 
+      ActorLink* p2 = f[2]->prev();
       t[0] = p0; t[1] = p1; t[2] = p2; t[3] = p3;
       np -= 4; t += 4; f += 4;
     }
@@ -4640,7 +4640,7 @@ namespace Gecode {
       ptrdiff_t m0, m1, m2, m3;
       ActorLink* p3 =
         static_cast<ActorLink*>(Support::ptrsplit(f[3],m3))->prev();
-      ActorLink* p0 = 
+      ActorLink* p0 =
         static_cast<ActorLink*>(Support::ptrsplit(f[0],m0))->prev();
       ActorLink* p1 =
         static_cast<ActorLink*>(Support::ptrsplit(f[1],m1))->prev();
@@ -4654,7 +4654,7 @@ namespace Gecode {
     }
     if (na >= 2) {
       ptrdiff_t m0, m1;
-      ActorLink* p0 = 
+      ActorLink* p0 =
         static_cast<ActorLink*>(Support::ptrsplit(f[0],m0))->prev();
       ActorLink* p1 =
         static_cast<ActorLink*>(Support::ptrsplit(f[1],m1))->prev();
@@ -4664,7 +4664,7 @@ namespace Gecode {
     }
     if (na > 0) {
       ptrdiff_t m0;
-      ActorLink* p0 = 
+      ActorLink* p0 =
         static_cast<ActorLink*>(Support::ptrsplit(f[0],m0))->prev();
       t[0] = static_cast<ActorLink*>(Support::ptrjoin(p0,m0));
     }

--- a/gecode/minimodel.hh
+++ b/gecode/minimodel.hh
@@ -100,22 +100,22 @@ namespace Gecode {
   /// Class for specifying integer propagation levels used by minimodel
   class IntPropLevels {
   protected:
-    IntPropLevel _linear2 : _IPL_BITS; ///< For binary linear
-    IntPropLevel _linear  : _IPL_BITS; ///< For n-ary linear
-    IntPropLevel _abs     : _IPL_BITS; ///< For absolute value
-    IntPropLevel _max2    : _IPL_BITS; ///< For binary maximum
-    IntPropLevel _max     : _IPL_BITS; ///< For n-ary maximum
-    IntPropLevel _min2    : _IPL_BITS; ///< For binary minimum
-    IntPropLevel _min     : _IPL_BITS; ///< For minimum
-    IntPropLevel _mult    : _IPL_BITS; ///< For multiplication
-    IntPropLevel _div     : _IPL_BITS; ///< For division
-    IntPropLevel _mod     : _IPL_BITS; ///< For modulo
-    IntPropLevel _sqr     : _IPL_BITS; ///< For square
-    IntPropLevel _sqrt    : _IPL_BITS; ///< For square root
-    IntPropLevel _pow     : _IPL_BITS; ///< For power
-    IntPropLevel _nroot   : _IPL_BITS; ///< For root
-    IntPropLevel _element : _IPL_BITS; ///< For element
-    IntPropLevel _ite     : _IPL_BITS; ///< For if-then-else
+    IntPropLevel _linear2 : IPL_BITS_; ///< For binary linear
+    IntPropLevel _linear  : IPL_BITS_; ///< For n-ary linear
+    IntPropLevel _abs     : IPL_BITS_; ///< For absolute value
+    IntPropLevel _max2    : IPL_BITS_; ///< For binary maximum
+    IntPropLevel _max     : IPL_BITS_; ///< For n-ary maximum
+    IntPropLevel _min2    : IPL_BITS_; ///< For binary minimum
+    IntPropLevel _min     : IPL_BITS_; ///< For minimum
+    IntPropLevel _mult    : IPL_BITS_; ///< For multiplication
+    IntPropLevel _div     : IPL_BITS_; ///< For division
+    IntPropLevel _mod     : IPL_BITS_; ///< For modulo
+    IntPropLevel _sqr     : IPL_BITS_; ///< For square
+    IntPropLevel _sqrt    : IPL_BITS_; ///< For square root
+    IntPropLevel _pow     : IPL_BITS_; ///< For power
+    IntPropLevel _nroot   : IPL_BITS_; ///< For root
+    IntPropLevel _element : IPL_BITS_; ///< For element
+    IntPropLevel _ite     : IPL_BITS_; ///< For if-then-else
   public:
     /// Initialize with default propagation level
     IntPropLevels(IntPropLevel ipl=IPL_DEF);

--- a/gecode/set/rel/common.hpp
+++ b/gecode/set/rel/common.hpp
@@ -38,9 +38,9 @@
  */
 
 #define GECODE_SET_ME_CHECK_VAL(p,f) {                   \
-    ModEvent __me__ ## __LINE__ = (p);                   \
-    if (me_failed(__me__ ## __LINE__)) return ES_FAILED; \
-    if (ME_GEN_ASSIGNED==(__me__ ## __LINE__))f=true; }
+    ModEvent _me_ ## __LINE__ = (p);                   \
+    if (me_failed(_me_ ## __LINE__)) return ES_FAILED; \
+    if (ME_GEN_ASSIGNED==(_me_ ## __LINE__))f=true; }
 
 #define GECODE_SET_ME_CHECK_VAL_B(modified, tell, f) \
   {                                                  \
@@ -63,7 +63,7 @@ namespace Gecode { namespace Set { namespace Rel {
   same(SetView x, SetView y) {
     return x == y;
   }
-  
+
   forceinline bool
   subsumesME(ModEvent me0, ModEvent me1, ModEvent me2, ModEvent me) {
     ModEvent cme = SetVarImp::me_combine(me0,SetVarImp::me_combine(me1, me2));


### PR DESCRIPTION
Identifiers with double underscores and identifiers starting with an
underscore followed by a captial letter are reserved, and using them
is undefined behaviour.  See more at
https://en.cppreference.com/w/cpp/language/identifiers

This change removes all the remaining cases in Gecode proper that
declares names with double underscores and those starting with a
single underscroe followed by a capital letter.

This fixes the remaining issues from issue #63