### PR TITLE
LGTM fixes

### DIFF
--- a/gecode/int/extensional/tuple-set.cpp
+++ b/gecode/int/extensional/tuple-set.cpp
@@ -108,7 +108,8 @@ namespace Gecode {
 
     // Initialization
     if (n_tuples == 0) {
-      delete td; td=nullptr;
+      heap.rfree(td);
+      td=nullptr;
       return;
     }
 

--- a/gecode/int/sorted/matching.hpp
+++ b/gecode/int/sorted/matching.hpp
@@ -73,7 +73,7 @@ namespace Gecode { namespace Int { namespace Sorted {
     for (int i = 0; i < xs; i++) {
       // the upper bound of the x-node should be minimal
       int perm = tau[i];
-      // find the iteration where \tau(i) became a maching candidate
+      // find the iteration where \tau(i) became a matching candidate
       int iter = seq[perm].iset;
       if (iter<0)
         return false;

--- a/gecode/int/sorted/sortsup.hpp
+++ b/gecode/int/sorted/sortsup.hpp
@@ -153,14 +153,14 @@ namespace Gecode { namespace Int { namespace Sorted {
     OfflineMin(OfflineMinItem[], int[], int);
     /**
      *  Find the set x belongs to
-     *  (wihtout path compression)
+     *  (without path compression)
      */
-    int  find(int x);
+    int find(int x);
     /**
      *  Find the set x belongs to
      *  (using path compression)
      */
-    int  find_pc(int x);
+    int find_pc(int x);
     /// Unite two sets \a a and \a b and label the union with \a c
     void unite(int a, int b, int c);
     /// Initialization of the datastructure
@@ -196,7 +196,7 @@ namespace Gecode { namespace Int { namespace Sorted {
   OfflineMin::find_pc(int x){
     int vsize = 0;
     while (sequence[x].parent != x) {
-      vertices[x] = x;
+      vertices[vsize++] = x;
       x = sequence[x].parent;
     }
     // x is now the root of the tree

--- a/gecode/int/sorted/sortsup.hpp
+++ b/gecode/int/sorted/sortsup.hpp
@@ -145,8 +145,11 @@ namespace Gecode { namespace Int { namespace Sorted {
    */
   class OfflineMin {
   private:
+    /// The set/forest of items.
     OfflineMinItem* sequence;
+    /// Scratch memory for path compression
     int* vertices;
+    /// The number of elements in the set
     int  n;
   public:
     OfflineMin(void);
@@ -194,15 +197,17 @@ namespace Gecode { namespace Int { namespace Sorted {
 
   forceinline int
   OfflineMin::find_pc(int x){
-    int vsize = 0;
+    int path_length = 0;
     while (sequence[x].parent != x) {
-      vertices[vsize++] = x;
+      vertices[path_length++] = x;
       x = sequence[x].parent;
     }
     // x is now the root of the tree
-    for (int i=0; i<vsize; i++)
+    // Compress path up to the root
+    for (int i=0; i < path_length-1; i++) {
       sequence[vertices[i]].parent = x;
-    // return the set, x belongs to
+    }
+    // return the set x belongs to
     return sequence[x].name;
   }
 
@@ -235,6 +240,7 @@ namespace Gecode { namespace Int { namespace Sorted {
       cur.succ   = i + 1;
       cur.iset   = -5;
     }
+    // no need to zero vertices, as it is only used as scratch area
   }
 
   forceinline int

--- a/gecode/int/val-set.hpp
+++ b/gecode/int/val-set.hpp
@@ -68,8 +68,7 @@ namespace Gecode { namespace Int {
         n++;
         return;
       } else {
-        // FIXME: HOW TO CAST HERE?
-        p = reinterpret_cast<RangeList**>(c->nextRef());
+        p = c->nextRef();
         c = *p;
       }
     }

--- a/gecode/iter/ranges-scale.hpp
+++ b/gecode/iter/ranges-scale.hpp
@@ -127,8 +127,8 @@ namespace Gecode { namespace Iter { namespace Ranges {
   ScaleUp<Val,UnsVal,I>::init(I& i0, int a0) {
     i = i0; a = a0;
     if (i()) {
-      cur = a * i.min();
-      end = a * i.max();
+      cur = static_cast<Val>(a) * static_cast<Val>(i.min());
+      end = static_cast<Val>(a) * static_cast<Val>(i.max());
     } else {
       cur = 1;
       end = 0;
@@ -139,8 +139,8 @@ namespace Gecode { namespace Iter { namespace Ranges {
   inline
   ScaleUp<Val,UnsVal,I>::ScaleUp(I& i0, int a0) : i(i0), a(a0) {
     if (i()) {
-      cur = a * i.min();
-      end = a * i.max();
+      cur = static_cast<Val>(a) * static_cast<Val>(i.min());
+      end = static_cast<Val>(a) * static_cast<Val>(i.max());
     } else {
       cur = 1;
       end = 0;

--- a/gecode/kernel/core.hpp
+++ b/gecode/kernel/core.hpp
@@ -4086,19 +4086,27 @@ namespace Gecode {
       pc.p.bid_sc |= sc_trace;
     }
     // Currently unused
-    if (p & AP_WEAKLY) {}
+    if (p & AP_WEAKLY) {
+      // Nothing to do
+    }
   }
 
   forceinline void
   Space::ignore(Actor& a, ActorProperty p, bool d) {
-    // Check wether array has already been discarded as space
+    // Check whether array has already been discarded as space
     // deletion is already in progress
     if ((p & AP_DISPOSE) && (d_fst != nullptr))
       ap_ignore_dispose(&a,d);
-    if (p & AP_VIEW_TRACE) {}
-    if (p & AP_TRACE) {}
+    if (p & AP_VIEW_TRACE) {
+      // Nothing to do
+    }
+    if (p & AP_TRACE) {
+      // Nothing to do
+    }
     // Currently unused
-    if (p & AP_WEAKLY) {}
+    if (p & AP_WEAKLY) {
+      // Nothing to do
+    }
   }
 
 


### PR DESCRIPTION
LGTM.com is a code analysis service. Their analysis of the Gecode source code is available here: https://lgtm.com/projects/g/Gecode/gecode/?mode=list

This branch fixes several of the warnings, including
  * A mismatched alloc with delete
  * Potential loss of precision in some multiplications
  * Missing path compression in the sorted propagator

There are several issues still left to investigate
  * Many copies of copy constructors without assignment operators
  * Many large objects passed by value

There are also a few warnings about usage of goto, which are not as interesting for us to fix (the usages are well known).