### PR TITLE
Use single option to activate cp-profiler

### DIFF
--- a/changelog.in
+++ b/changelog.in
@@ -76,6 +76,22 @@ Date: 2020-??-??
 Let's see.
 
 [ENTRY]
+Module: flatzinc
+What:   change
+Rank:   minor
+[DESCRIPTION]
+Accept combined -cpprofiler flag for activating CP-Profiler and always
+send information to profiler.
+
+[ENTRY]
+Module: driver
+What:   change
+Rank:   minor
+[DESCRIPTION]
+Accept combined -cpprofiler flag for activating CP-Profiler instead of
+using separate script mode.
+
+[ENTRY]
 Module: test
 What:   bug
 Rank:   minor

--- a/gecode/driver.hh
+++ b/gecode/driver.hh
@@ -96,7 +96,6 @@ namespace Gecode {
     SM_TIME,      ///< Measure average runtime
     SM_STAT,      ///< Print statistics for script
     SM_GIST,      ///< Run script in Gist
-    SM_CPPROFILER ///< Run script with CP-profiler
   };
 
   /**
@@ -343,6 +342,30 @@ namespace Gecode {
       virtual void help(void);
     };
 
+    /**
+     * \brief Profiler option
+     *
+     */
+    class GECODE_DRIVER_EXPORT ProfilerOption : public BaseOption {
+     protected:
+      unsigned int cur_port;  ///< Current port
+      int cur_execution_id;   ///< Current execution ID
+     public:
+      /// Initialize for option \a o and explanation \a e and default value \a v
+      ProfilerOption(const char* o, const char* e, unsigned int p = 0, int v = -1);
+      /// Set default port to \a p
+      void port(unsigned int p);
+      /// Return current port
+      unsigned int port(void) const;
+      /// Set default execution ID to \a i
+      void execution_id(int i);
+      /// Return current execution ID
+      int execution_id(void) const;
+      /// Parse option at first position and return number of parsed arguments
+      virtual int parse(int argc, char* argv[]);
+      /// Print help text
+      virtual void help(void);
+    };
   }
 
   /**
@@ -434,9 +457,7 @@ namespace Gecode {
     Driver::TraceOption       _trace;         ///< Trace flags for tracing
 
 #ifdef GECODE_HAS_CPPROFILER
-    Driver::IntOption         _profiler_id;   ///< Use this execution id for the CP-profiler
-    Driver::UnsignedIntOption _profiler_port; ///< Connect to this port
-    Driver::BoolOption        _profiler_info; ///< Whether solution information should be sent to the CPProfiler
+    Driver::ProfilerOption    _profiler;      ///< Options for the CP Profiler
 #endif
 
     //@}

--- a/gecode/driver/options.cpp
+++ b/gecode/driver/options.cpp
@@ -486,6 +486,23 @@ namespace Gecode {
       cerr << endl << "\t\t" << exp << endl;
     }
 
+    
+    int ProfilerOption::parse(int argc, char* argv[]) {
+      if (char* a = argument(argc, argv)) {
+        char* sep = strchr(a, ',');
+        if (!sep) {
+          std::cerr << "Wrong argument \"" << a << "\" for option \"" << iopt << "\"" << std::endl;
+          exit(EXIT_FAILURE);
+        }
+        cur_execution_id = static_cast<unsigned int>(atoi(a));
+        cur_port = atoi(sep + 1);
+        return 2;
+      }
+      return 0;
+    }
+
+    void ProfilerOption::help(void) { std::cerr << '\t' << iopt << " (unsigned int,int) default: " << cur_port << "," << cur_execution_id << std::endl << "\t\t" << exp << std::endl; }
+
 
   }
 
@@ -641,10 +658,7 @@ namespace Gecode {
 
 #ifdef GECODE_HAS_CPPROFILER
       ,
-      _profiler_id("cpprofiler-id", "use this execution id with CP-profiler", 0),
-      _profiler_port("cpprofiler-port", "connect to CP-profiler on this port",
-                     Search::Config::cpprofiler_port),
-      _profiler_info("cpprofiler-info", "send solution information to CP-profiler", false) 
+      _profiler("cpprofiler", "use this execution id and port (comma separated) with CP-profiler")
 #endif
   {
 
@@ -652,7 +666,6 @@ namespace Gecode {
     _mode.add(SM_TIME,       "time");
     _mode.add(SM_STAT,       "stat");
     _mode.add(SM_GIST,       "gist");
-    _mode.add(SM_CPPROFILER, "cpprofiler");
 
     _restart.add(RM_NONE,"none");
     _restart.add(RM_CONSTANT,"constant");
@@ -672,9 +685,7 @@ namespace Gecode {
     add(_mode); add(_iterations); add(_samples); add(_print_last);
     add(_out_file); add(_log_file); add(_trace);
 #ifdef GECODE_HAS_CPPROFILER
-    add(_profiler_id);
-    add(_profiler_port);
-    add(_profiler_info);
+    add(_profiler);
 #endif
   }
 

--- a/gecode/driver/options.hpp
+++ b/gecode/driver/options.hpp
@@ -173,6 +173,18 @@ namespace Gecode {
       return cur;
     }
 
+    /*
+     * Profiler option
+     *
+     */
+    inline
+    ProfilerOption::ProfilerOption(const char* o, const char* e, unsigned int p, int i)
+      : BaseOption(o,e), cur_port(p), cur_execution_id(i) {}
+    inline void ProfilerOption::port(unsigned int p) { cur_port = p; }
+    inline unsigned int ProfilerOption::port(void) const { return cur_port; }
+    inline void ProfilerOption::execution_id(int i) { cur_execution_id = i; }
+    inline int ProfilerOption::execution_id(void) const { return cur_execution_id; }
+
   }
 
   /*
@@ -530,29 +542,20 @@ namespace Gecode {
    */
   inline void
   Options::profiler_id(int i) {
-    _profiler_id.value(i);
+    _profiler.execution_id(i);
   }
   inline int
   Options::profiler_id(void) const {
-    return _profiler_id.value();
+    return _profiler.execution_id();
   }
   inline void
   Options::profiler_port(unsigned int p) {
-    _profiler_port.value(p);
+    _profiler.port(p);
   }
   inline unsigned int
   Options::profiler_port(void) const {
-    return _profiler_port.value();
+    return _profiler.port();
   }
-  inline void
-  Options::profiler_info(bool b) {
-    _profiler_info.value(b);
-  }
-  inline bool
-  Options::profiler_info(void) const {
-    return _profiler_info.value();
-  }
-
 #endif
 
 #ifdef GECODE_HAS_GIST

--- a/gecode/driver/script.hpp
+++ b/gecode/driver/script.hpp
@@ -349,22 +349,20 @@ namespace Gecode { namespace Driver {
 #else
         goto solution;
 #endif
-      case SM_CPPROFILER:
-#ifdef GECODE_HAS_CPPROFILER
-        {
-          CPProfilerSearchTracer::GetInfo* getInfo = nullptr;
-          if (o.profiler_info())
-            getInfo = new ScriptGetInfo<BaseSpace>;
-          so.tracer = new CPProfilerSearchTracer
-            (o.profiler_id(), o.name(), o.profiler_port(), getInfo);
-        }
-        /* FALL THROUGH */
-#endif
       case SM_SOLUTION:
 #ifndef GECODE_HAS_GIST
       solution:
 #endif
         {
+#ifdef GECODE_HAS_CPPROFILER
+          if (o.profiler_port()) {
+            CPProfilerSearchTracer::GetInfo* getInfo = nullptr;
+            if (o.profiler_info())
+              getInfo = new ScriptGetInfo<BaseSpace>;
+            so.tracer = new CPProfilerSearchTracer
+              (o.profiler_id(), o.name(), o.profiler_port(), getInfo);
+          }
+#endif
           l_out << o.name() << endl;
           Support::Timer t;
           unsigned long long int s_l =

--- a/gecode/flatzinc.hh
+++ b/gecode/flatzinc.hh
@@ -255,11 +255,7 @@ namespace Gecode { namespace FlatZinc {
       Gecode::Driver::StringValueOption _output;     ///< Output file
 
 #ifdef GECODE_HAS_CPPROFILER
-
-      Gecode::Driver::IntOption         _profiler_id; ///< Use this execution id for the CP-profiler
-      Gecode::Driver::UnsignedIntOption _profiler_port; ///< Connect to this port
-      Gecode::Driver::BoolOption        _profiler_info; ///< Whether solution information should be sent to the CP-profiler
-
+      Gecode::Driver::ProfilerOption    _profiler; ///< Use this execution id for the CP-profiler
 #endif
 
       //@}
@@ -295,16 +291,12 @@ namespace Gecode { namespace FlatZinc {
 
 #ifdef GECODE_HAS_CPPROFILER
       ,
-      _profiler_id("cpprofiler-id", "use this execution id with cpprofiler", 0),
-      _profiler_port("cpprofiler-port", "connect to cpprofiler on this port", 6565),
-      _profiler_info("cpprofiler-info", "send solution information to cpprofiler", false)
-
+      _profiler("cpprofiler", "use this execution id and port (comma separated) with CP-profiler")
 #endif
     {
       _mode.add(Gecode::SM_SOLUTION, "solution");
       _mode.add(Gecode::SM_STAT, "stat");
       _mode.add(Gecode::SM_GIST, "gist");
-      _mode.add(Gecode::SM_CPPROFILER, "cpprofiler");
       _restart.add(RM_NONE,"none");
       _restart.add(RM_CONSTANT,"constant");
       _restart.add(RM_LINEAR,"linear");
@@ -323,9 +315,7 @@ namespace Gecode { namespace FlatZinc {
       add(_mode); add(_stat);
       add(_output);
 #ifdef GECODE_HAS_CPPROFILER
-      add(_profiler_id);
-      add(_profiler_port);
-      add(_profiler_info);
+      add(_profiler);
 #endif
     }
 
@@ -382,9 +372,9 @@ namespace Gecode { namespace FlatZinc {
 
 #ifdef GECODE_HAS_CPPROFILER
 
-    int profiler_id(void) const { return _profiler_id.value(); }
-    unsigned int profiler_port(void) const { return _profiler_port.value(); }
-    bool profiler_info(void) const { return _profiler_info.value(); }
+    int profiler_id(void) const { return _profiler.execution_id(); }
+    unsigned int profiler_port(void) const { return _profiler.port(); }
+    bool profiler_info(void) const { return true; }
 
 #endif
 

--- a/gecode/flatzinc/flatzinc.cpp
+++ b/gecode/flatzinc/flatzinc.cpp
@@ -1842,8 +1842,7 @@ namespace Gecode { namespace FlatZinc {
     o.a_d = opt.a_d();
 
 #ifdef GECODE_HAS_CPPROFILER
-
-    if (opt.mode() == SM_CPPROFILER) {
+    if (opt.profiler_port()) {
       FlatZincGetInfo* getInfo = nullptr;
       if (opt.profiler_info())
         getInfo = new FlatZincGetInfo(p);


### PR DESCRIPTION
Uses the new combined `-cpprofiler` standard flag. Always sends info when profiling.