### PR TITLE
Parallel tests

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -1280,7 +1280,7 @@ test: mkcompiledirs
 
 # A basic integrity test
 check: test
-	$(RUNENVIRONMENT) $(TESTEXE) -iter 2 -test Branch::Int::Dense::3 \
+	$(RUNENVIRONMENT) $(TESTEXE) -iter 2 -threads 0 -test Branch::Int::Dense::3 \
 			   -test FlatZinc::magic_square \
 			   -test Int::Arithmetic::Abs \
 			   -test Int::Arithmetic::ArgMax \

--- a/changelog.in
+++ b/changelog.in
@@ -69,6 +69,13 @@ Date: 2020-??-??
 [DESCRIPTION]
 Let's see.
 
+[ENTRY]
+Module: other
+What:   change
+Rank:   major
+[DESCRIPTION]
+Gecode now requires C++ 11, the support for compiling without C++ 11
+has been removed.
 
 [ENTRY]
 Module: kernel

--- a/changelog.in
+++ b/changelog.in
@@ -70,6 +70,24 @@ Date: 2020-??-??
 Let's see.
 
 [ENTRY]
+Module: test
+What:   new
+Rank:   major
+[DESCRIPTION]
+Teests can now be run using multiple threads. Use the -threads n argument to
+the test runner to run the tests using n threads. A value of 0 uses the number
+of processing units to set the thread count.
+Using 6 parallel threads, running the full test suite went from 4 hours 15 minutes
+to 55 minutes on a 6-core machine. While not a perfect speed-up, it significantly
+reduces the time to test Gecode.
+[MORE]
+Due to the the high frequency of memory operations when running tests in parallel,
+the system allocation on macOS has a hard time keeping up. To get full performance,
+we recommend using another allocator, such as for example mimalloc.
+Note also that logging and multiple threads for running tests do not work at the
+same time.
+
+[ENTRY]
 Module: flatzinc
 What:   change
 Rank:   minor

--- a/changelog.in
+++ b/changelog.in
@@ -70,6 +70,17 @@ Date: 2020-??-??
 Let's see.
 
 [ENTRY]
+Module: kernel
+What:   change
+Rank:   minor
+[DESCRIPTION]
+Use std::atomic for the global propagator identifier counter instead of guarding
+using Support::Mutex.
+[MORE]
+Using a normal int and locking took too much time when running
+tests in parallel on macOS.
+
+[ENTRY]
 Module: test
 What:   new
 Rank:   major
@@ -146,7 +157,7 @@ undefined behaviour. Use guards of the form GECODE_KERNEL_HH instead.
 Similarly, names with a single leading underscore followed by a
 capital letter are also reserved, and usage is thus undefined
 behaviour, and are removed.
-	
+
 [ENTRY]
 Module: flatzinc
 What:   new
@@ -317,7 +328,7 @@ Rank:   minor
 Thanks:	Jip J. Dekker
 [DESCRIPTION]
 Enable support for half-reified constraints in the Gecode MiniZinc
-library. Half-reified constraints are used when a MiniZinc 
+library. Half-reified constraints are used when a MiniZinc
 expression has to be reified and is detected to be in a positive
 context. If no Half-reified constraint has been made available by
 solver, the full reification will be used. Half-reifed constraints
@@ -1387,7 +1398,7 @@ Date: 2017-04-18
 [DESCRIPTION]
 This is a rather major release, fixing a number of bugs and
 adding quite a number of new features. Some of the features
-require changes to your models. 
+require changes to your models.
 
 In more detail: extended tracing so that all propagator
 executions and commit operations can be traced; renamed activity
@@ -2500,7 +2511,7 @@ it is done.
 Module: flatzinc
 What:   new
 Rank:   minor
-Thanks: Mark Manser 
+Thanks: Mark Manser
 [DESCRIPTION]
 An option -step now can pass an improvement step for
 optimization of float problems.
@@ -2511,7 +2522,7 @@ What:   change
 Rank:   major
 [DESCRIPTION]
 All scripts now must call the constructor of their base class
-with an option argument. 
+with an option argument.
 
 Note that you will have to change your models by a call to the
 constructor of the script class with an option argument!
@@ -2520,7 +2531,7 @@ constructor of the script class with an option argument!
 Module: driver
 What:   new
 Rank:   minor
-Thanks: Mark Manser 
+Thanks: Mark Manser
 [DESCRIPTION]
 An option -step now can pass an improvement step to scripts of
 type FloatMinimizeScript and FloatMaximizeScript.
@@ -2529,7 +2540,7 @@ type FloatMinimizeScript and FloatMaximizeScript.
 Module: minimodel
 What:   new
 Rank:   minor
-Thanks: Mark Manser 
+Thanks: Mark Manser
 [DESCRIPTION]
 The classes FloatMinimizeSpace and FloatMaximizeSpace can be
 created with an improvement step for optimization.
@@ -2808,7 +2819,7 @@ What:   bug
 Rank:   minor
 Thanks:	Léonard Benedetti
 [DESCRIPTION]
-Removed potentially undefined behavior for regular expressions. 
+Removed potentially undefined behavior for regular expressions.
 
 [ENTRY]
 Module: flatzinc
@@ -2899,7 +2910,7 @@ Module: flatzinc
 What:   performance
 Rank:   minor
 [DESCRIPTION]
-Treat equality constraints in FlatZinc as aliases instead of posting 
+Treat equality constraints in FlatZinc as aliases instead of posting
 propagators, and post simple domain constraints before more complex
 propagators to help post the most efficient versions.
 
@@ -4521,7 +4532,7 @@ What:   bug
 Rank:   minor
 Thanks: Gustavo Gutierrez
 [DESCRIPTION]
-Install generated variable implementation headers instead of the shipped 
+Install generated variable implementation headers instead of the shipped
 versions (fixes a problem when building Gecode in a separate directory).
 
 [ENTRY]
@@ -4769,7 +4780,7 @@ Module: flatzinc
 What:   new
 Rank:   major
 [DESCRIPTION]
-Added native support for the no-overlap constraint (called diffn in 
+Added native support for the no-overlap constraint (called diffn in
 MiniZinc/FlatZinc).
 
 [ENTRY]
@@ -4853,7 +4864,7 @@ Module: flatzinc
 What:   new
 Rank:   minor
 [DESCRIPTION]
-Added native support for link_set_to_booleans, 
+Added native support for link_set_to_booleans,
 global_cardinality_low_up_closed, and decreasing_bool.
 
 [ENTRY]
@@ -4869,7 +4880,7 @@ Module: search
 What:   bug
 Rank:   minor
 [DESCRIPTION]
-Fixed memory leak when passing a failed space to a search engine with cloning 
+Fixed memory leak when passing a failed space to a search engine with cloning
 option set to false.
 
 [ENTRY]
@@ -4877,8 +4888,8 @@ Module: kernel
 What:   new
 Rank:   minor
 [DESCRIPTION]
-Moved RangeList class, which is a list of ranges implemented as a FreeList, 
-from the set module into the kernel. Also added corresponding 
+Moved RangeList class, which is a list of ranges implemented as a FreeList,
+from the set module into the kernel. Also added corresponding
 Iter::Ranges::RangeList iterator.
 
 [ENTRY]
@@ -4916,7 +4927,7 @@ What:   bug
 Rank:   minor
 [DESCRIPTION]
 Changed keyboard shortcuts in Gist so that they work on all platforms: "Inspect"
-is now Ctrl+number of inspector, for "Inspect before fixpoint" press Alt in 
+is now Ctrl+number of inspector, for "Inspect before fixpoint" press Alt in
 addition (on Mac OS, use the Command key instead of Ctrl).
 
 [ENTRY]
@@ -4942,7 +4953,7 @@ Module: set
 What:   bug
 Rank:   minor
 [DESCRIPTION]
-The constructors for set variable arrays and argument arrays threw incorrect 
+The constructors for set variable arrays and argument arrays threw incorrect
 VariableEmptyDomain exceptions.
 
 [ENTRY]
@@ -4974,7 +4985,7 @@ Module: flatzinc
 What:   change
 Rank:   minor
 [DESCRIPTION]
-Adapted the MiniZinc declarations and the command line options for 
+Adapted the MiniZinc declarations and the command line options for
 Gecode/FlatZinc to MiniZinc 1.3. The fz binary now works with the
 minizinc driver script.
 
@@ -4992,7 +5003,7 @@ What:   bug
 Rank:   minor
 Thanks: Håkan Kjellerstrand
 [DESCRIPTION]
-Fixed the MiniZinc definition for the circuit constraints to work with 
+Fixed the MiniZinc definition for the circuit constraints to work with
 arbitrarily indexed arrays.
 
 [ENTRY]
@@ -5241,7 +5252,7 @@ What:   bug
 Rank:   minor
 Thanks: Kish Shen
 [DESCRIPTION]
-The reified dom constraint failed instead of setting the BoolVar to 0 when the 
+The reified dom constraint failed instead of setting the BoolVar to 0 when the
 minimum argument given was greater than the maximum.
 
 [ENTRY]
@@ -5250,9 +5261,9 @@ What:   performance
 Rank:   minor
 Thanks: Kish Shen
 [DESCRIPTION]
-Fixed sortedness constraint by replacing an algorithm that is linear in the 
-width of the union of all domains with an algorithm that is quadratic in the 
-number of variables. The previous algorithm crashed for domains with large 
+Fixed sortedness constraint by replacing an algorithm that is linear in the
+width of the union of all domains with an algorithm that is quadratic in the
+number of variables. The previous algorithm crashed for domains with large
 values due to excessive memory use.
 
 [ENTRY]
@@ -5260,9 +5271,9 @@ Module: int
 What:   performance
 Rank:   minor
 [DESCRIPTION]
-Using ICL_DOM for binary linear equations with unit coefficients (such as x = 
-y+3) is now implemented using the much more efficient binary equality 
-propagator instead of the linear equation propagator (which has worst case 
+Using ICL_DOM for binary linear equations with unit coefficients (such as x =
+y+3) is now implemented using the much more efficient binary equality
+propagator instead of the linear equation propagator (which has worst case
 exponential runtime).
 
 [ENTRY]
@@ -5288,7 +5299,7 @@ Module: flatzinc
 What:   performance
 Rank:   minor
 [DESCRIPTION]
-The FlatZinc parser now uses hash maps instead of STL maps, which 
+The FlatZinc parser now uses hash maps instead of STL maps, which
 significantly increases parsing performance for larger files.
 Furthermore, a single symbol table is used, also increasing
 performance and allowing to report duplicate symbol errors,
@@ -5306,7 +5317,7 @@ initialization and element addition to arrays); state-of-the-art
 unary and cumulative scheduling propagators (including optional
 and flexible tasks); major cleanups of the variable and view
 infrastructure (now also documented in MPG); cleanups of the
-examples; several other fixes and performance improvements. 
+examples; several other fixes and performance improvements.
 
 This release is the first to be accompanied by a complete version
 of "Modeling and Programming in Gecode" which has been extended
@@ -5391,7 +5402,7 @@ Module: gist
 What:   change
 Rank:   minor
 [DESCRIPTION]
-If an inspector throws an exception, an error message is 
+If an inspector throws an exception, an error message is
 printed indicating which inspector caused the problem.
 Previously, Gist would crash with a Qt error that was difficult
 to trace.
@@ -5401,7 +5412,7 @@ Module: flatzinc
 What:   bug
 Rank:   minor
 [DESCRIPTION]
-Fixed garbage collection of variables that are not printed. The 
+Fixed garbage collection of variables that are not printed. The
 bug lead to variables being mixed up in the output.
 
 [ENTRY]
@@ -5463,7 +5474,7 @@ Module: example
 What:   change
 Rank:   minor
 [DESCRIPTION]
-The Nonogram example now uses AFC as the default branching and 
+The Nonogram example now uses AFC as the default branching and
 includes some more instances.
 
 [ENTRY]
@@ -5478,7 +5489,7 @@ Module: other
 What:   change
 Rank:   minor
 [DESCRIPTION]
-The configure script now checks for qmake-qt4 and moc-qt4, which are used on 
+The configure script now checks for qmake-qt4 and moc-qt4, which are used on
 some Linux systems to distinguish between Qt3 and Qt4.
 
 [ENTRY]
@@ -5533,7 +5544,7 @@ Module: int
 What: 	change
 Rank:	minor
 [DESCRIPTION]
-IntArgs with simple sequences of values can now be created using the 
+IntArgs with simple sequences of values can now be created using the
 IntArgs::create static member function.
 
 [ENTRY]
@@ -5593,7 +5604,7 @@ What:   bug
 Rank:   minor
 Thanks: David Zaremby
 [DESCRIPTION]
-Fixed bug in interactive search where every move in the tree required 
+Fixed bug in interactive search where every move in the tree required
 recomputation.
 
 
@@ -5651,9 +5662,9 @@ Module: gist
 What:   new
 Rank:   major
 [DESCRIPTION]
-In addition to inspectors, you can now also register comparators, which can be 
-used to compare two nodes in the tree. In combination with the option to 
-compare before computing a fixpoint of the second node, this lets you see what 
+In addition to inspectors, you can now also register comparators, which can be
+used to compare two nodes in the tree. In combination with the option to
+compare before computing a fixpoint of the second node, this lets you see what
 exactly was modified by a branching.
 
 [ENTRY]
@@ -5661,7 +5672,7 @@ Module: set
 What:   bug
 Rank:   minor
 [DESCRIPTION]
-Fixed channeling between set and integer variables which did not propagate 
+Fixed channeling between set and integer variables which did not propagate
 enough.
 
 [ENTRY]
@@ -5677,8 +5688,8 @@ Module: gist
 What:   bug
 Rank:   minor
 [DESCRIPTION]
-Missing export declarations prevented embedding Gist as a widget. There is 
-now example code for embedding Gist in the directory 
+Missing export declarations prevented embedding Gist as a widget. There is
+now example code for embedding Gist in the directory
 gecode/gist/standalone-example.
 
 [ENTRY]
@@ -5688,7 +5699,7 @@ Rank:   major
 [DESCRIPTION]
 Gist can now stop exploration after all alternatives of a certain branching
 are exhausted. This feature can be turned on by posting a special branching
-using the Gist::stopBranch post function. Gist will then stop whenever that 
+using the Gist::stopBranch post function. Gist will then stop whenever that
 special branching becomes active.
 
 [ENTRY]
@@ -5725,7 +5736,7 @@ Module: set
 What:   removed
 Rank:   minor
 [DESCRIPTION]
-Removed Set::IntSetPropagator and Set::IntSetRePropagator because they are 
+Removed Set::IntSetPropagator and Set::IntSetRePropagator because they are
 subsumed by the MixBinaryPropagator patterns.
 
 [ENTRY]
@@ -5740,9 +5751,9 @@ Module: gist
 What:   performance
 Rank:   major
 [DESCRIPTION]
-Scrolling and zooming have been reimplemented. The new implementation is more 
-efficient and works around problems that occurred with large trees on some 
-platforms. Zooming is now more intuitive, keeping the current center 
+Scrolling and zooming have been reimplemented. The new implementation is more
+efficient and works around problems that occurred with large trees on some
+platforms. Zooming is now more intuitive, keeping the current center
 centered. You can now also zoom by pressing shift while using the mouse wheel.
 
 [ENTRY]
@@ -5778,9 +5789,9 @@ Module: flatzinc
 What:   change
 Rank:   minor
 [DESCRIPTION]
-Comply with MiniZinc 1.1. String literals are not allowed any longer 
-except in annotations, the solver outputs UNKNOWN and UNSATISFIABLE 
-instead of just ==========, and the global constraints all_equal, 
+Comply with MiniZinc 1.1. String literals are not allowed any longer
+except in annotations, the solver outputs UNKNOWN and UNSATISFIABLE
+instead of just ==========, and the global constraints all_equal,
 decreasing_int, and decreasing_bool are supported.
 
 
@@ -5905,7 +5916,7 @@ Module: flatzinc
 What:   change
 Rank:   minor
 [DESCRIPTION]
-Added command line option -print, which controls whether all solutions are 
+Added command line option -print, which controls whether all solutions are
 printed or only the last one that is found, and -search, to choose between
 branch-and-bound and restart optimization.
 
@@ -5924,7 +5935,7 @@ Module: flatzinc
 What:   bug
 Rank:   minor
 [DESCRIPTION]
-The FlatZinc interpreter ignored the -c-d and -a-d command line 
+The FlatZinc interpreter ignored the -c-d and -a-d command line
 switches when used with Gist.
 
 [ENTRY]
@@ -5972,7 +5983,7 @@ Module: gist
 What:   bug
 Rank:   minor
 [DESCRIPTION]
-Avoid inter-thread call to QWidget::update, which apparently causes a slight 
+Avoid inter-thread call to QWidget::update, which apparently causes a slight
 memory leak (and warning messages on stderr) on Mac OS.
 
 
@@ -6148,7 +6159,7 @@ What:   change
 Rank:   minor
 [DESCRIPTION]
 The semantics of division and modulo has changed to match the C standard. This
-means that the operations round towards zero, and that the result of the 
+means that the operations round towards zero, and that the result of the
 modulo has the same sign as its first argument.
 
 [ENTRY]
@@ -6445,7 +6456,7 @@ Module: kernel
 What:   change
 Rank:   major
 [DESCRIPTION]
-A branching is now a brancher and a branching description is now a choice. 
+A branching is now a brancher and a branching description is now a choice.
 [MORE]
 Classes and member functions have been renamed accordingly. The
 change is necessary due to proper explanation in the forthcoming
@@ -6464,8 +6475,8 @@ What:   change
 Rank:   minor
 [DESCRIPTION]
 The Gist console now has a toolbar that provides buttons to clear the text
-as well as to configure the console window to stay on top of Gist. 
-Furthermore, after adding output, the console now automatically scrolls to the 
+as well as to configure the console window to stay on top of Gist.
+Furthermore, after adding output, the console now automatically scrolls to the
 bottom.
 
 [ENTRY]
@@ -6693,7 +6704,7 @@ Module: gist
 What:   bug
 Rank:   minor
 [DESCRIPTION]
-Fixed a dead lock that could occur when closing the Gist main window while 
+Fixed a dead lock that could occur when closing the Gist main window while
 search is still running.
 
 [ENTRY]
@@ -6717,8 +6728,8 @@ Module: gist
 What:   change
 Rank:   minor
 [DESCRIPTION]
-Small user interface changes: disable search from hidden nodes, add depth 
-information to status bar, and add statistics for subtrees (available from the 
+Small user interface changes: disable search from hidden nodes, add depth
+information to status bar, and add statistics for subtrees (available from the
 node context menu and the Node menu).
 
 [ENTRY]
@@ -6789,7 +6800,7 @@ Added a new module "driver" as a commandline driver for
 scripts. This is due to popular request: most people have been
 using the support functionality for examples anyway. This
 function is now wrapped into a proper module (and Example is
-now called Script to be more general). See "Modeling with Gecode" 
+now called Script to be more general). See "Modeling with Gecode"
 for documentation.
 
 [ENTRY]
@@ -7052,7 +7063,7 @@ Module: set
 What:   new
 Rank:   minor
 [DESCRIPTION]
-More set branching strategies have been added (for instance random variable 
+More set branching strategies have been added (for instance random variable
 and value selection), as well as set assignment.
 
 [ENTRY]
@@ -7143,7 +7154,7 @@ Module: kernel
 What:   change
 Rank:   minor
 [DESCRIPTION]
-Introduced CopiedHandle as a new base class for SharedHandle. 
+Introduced CopiedHandle as a new base class for SharedHandle.
 [MORE]
 A copied handle provides access to an object that is used by
 entities in a space, and that is copied when then space is
@@ -7190,7 +7201,7 @@ What:   bug
 Rank:   minor
 Thanks: Denys Duchier
 [DESCRIPTION]
-Fixed constructors for set variables. They now throw proper exceptions when 
+Fixed constructors for set variables. They now throw proper exceptions when
 trying to create empty variable domains.
 
 [ENTRY]
@@ -7199,7 +7210,7 @@ What:   new
 Rank:   minor
 Thanks: Denys Duchier
 [DESCRIPTION]
-Added reified propagators constraining an integer variable to be the minimum 
+Added reified propagators constraining an integer variable to be the minimum
 or maximum element of a set variable.
 
 [ENTRY]
@@ -7331,7 +7342,7 @@ Module: other
 What:   change
 Rank:   major
 [DESCRIPTION]
-Changed naming scheme for files. 
+Changed naming scheme for files.
 [MORE]
 All files with extension .cc have been renamed to .cpp, and .icc
 has become .hpp. This avoids conflicts as .icc is typically used
@@ -7352,7 +7363,7 @@ Module: set
 What:   change
 Rank:   minor
 [DESCRIPTION]
-Reorganized the internal data structures of set variables so that each 
+Reorganized the internal data structures of set variables so that each
 variable takes up 8 bytes less memory on 64 bit machines.
 
 [ENTRY]
@@ -7363,8 +7374,8 @@ Rank:   minor
 The index structure for variable dependencies is now implemented using integers
 instead of pointers, saving memory on 64 bit machines.
 [MORE]
-For example, the index 
-structure of integer variables is now 40% smaller, for Boolean variables 
+For example, the index
+structure of integer variables is now 40% smaller, for Boolean variables
 (which have the smallest possible index structure) we still save 16%.
 
 [ENTRY]
@@ -7389,7 +7400,7 @@ Module: kernel
 What:   change
 Rank:   major
 [DESCRIPTION]
-%Gecode now supports weakly monotonic propagators. 
+%Gecode now supports weakly monotonic propagators.
 [MORE]
 A weakly monotonic propagator must only be able to decide for
 assignments whether they are solutions or not (which is a very
@@ -7408,7 +7419,7 @@ What:   change
 Rank:   minor
 [DESCRIPTION]
 The functions force and unforce of an actor to force disposal
-have been removed. 
+have been removed.
 [MORE]
 Now, the new interface based on notice and ignore using actor
 properties must be used instead. So, instead of "force(home)",
@@ -7457,7 +7468,7 @@ What:   change
 Rank:   major
 [DESCRIPTION]
 Now everything is passed as reference (Space, Propagator,
-ModEventDelta, Advisor, Branching, and BranchingDesc). 
+ModEventDelta, Advisor, Branching, and BranchingDesc).
 [MORE]
 The reason for this massive change is to be more C++ compliant
 and make the interfaces more consistent (at some places things
@@ -7483,7 +7494,7 @@ Module: other
 What:   change
 Rank:   major
 [DESCRIPTION]
-The memory management has been completely reworked. 
+The memory management has been completely reworked.
 [MORE]
 It is now more robust, more portable (does not use alloca any
 longer), more efficient, fits C++ better and is much easier too
@@ -7577,7 +7588,7 @@ What:   change
 Rank:   major
 [DESCRIPTION]
 The values for variable and value selection for branching have
-been made consistent and extended. 
+been made consistent and extended.
 [MORE]
 The following values have been renamed:
  - SET_VAR_MIN_CARD -> SET_VAR_SIZE_MIN
@@ -7635,13 +7646,13 @@ What:   bug
 Rank:   major
 [DESCRIPTION]
 Fixed a bug in the memory alignment on Windows 64bit (very hard to reproduce).
-	
+
 [ENTRY]
 Module: other
 What:   new
 Rank:   minor
 [DESCRIPTION]
-Added configure options for adding a prefix and a suffix to the names of the 
+Added configure options for adding a prefix and a suffix to the names of the
 compiled libraries.
 
 [ENTRY]
@@ -7651,13 +7662,13 @@ Rank:   major
 [DESCRIPTION]
 Fixed a bug in the domain consistent distinct propagator that would cause
 a stack overflow under rare circumstances.
-	
+
 [ENTRY]
 Module: set
 What:   bug
 Rank:   major
 [DESCRIPTION]
-The ternary intersection propagator was incorrect if any of the sets had a 
+The ternary intersection propagator was incorrect if any of the sets had a
 maximum cardinality of Set::Limits::card.
 
 [ENTRY]
@@ -7690,7 +7701,7 @@ Module: int
 What:   new
 Rank:   minor
 [DESCRIPTION]
-The channel constraint now comes in a version that allows to specify offsets 
+The channel constraint now comes in a version that allows to specify offsets
 to the array indices.
 
 [ENTRY]
@@ -7707,7 +7718,7 @@ Module: other
 What:   new
 Rank:   minor
 [DESCRIPTION]
-The Makefile has a new target, check, which performs a minimal integrity check 
+The Makefile has a new target, check, which performs a minimal integrity check
 using some tests from the test suite.
 
 [ENTRY]
@@ -7810,7 +7821,7 @@ Module: kernel
 What:   change
 Rank:   minor
 [DESCRIPTION]
-Cleaned up Reflection::Var type, overloading did not conform to the C++ 
+Cleaned up Reflection::Var type, overloading did not conform to the C++
 standard.
 
 [ENTRY]
@@ -7911,7 +7922,7 @@ the first release where really everything that we can test
 been systematically tested. So, better switch now to 2.1.0!
 
 Apart from that, the value range for variables has been increased
-(basically, 32 bits minus three values, so that is 32 bits), the reflection 
+(basically, 32 bits minus three values, so that is 32 bits), the reflection
 API is now fully functional and no longer considered experimental, and we have
 the usual small additions.
 
@@ -7999,8 +8010,8 @@ Rank:   major
 [DESCRIPTION]
 Fixed bugs in several set constraints:
 rel(Space*,SetVar,IntRelType irt,IntVar) for irt=IRT_NQ,
-rel(Space*,SetVar,SetOpType sot,const IntSet&,SetRelType srt,SetVar) for 
-sot=SOT_MINUS, srt=SRT_SUP, selectDisjoint, selectUnion with constant IntSet 
+rel(Space*,SetVar,SetOpType sot,const IntSet&,SetRelType srt,SetVar) for
+sot=SOT_MINUS, srt=SRT_SUP, selectDisjoint, selectUnion with constant IntSet
 arguments, dom with SRT_NQ.
 
 [ENTRY]
@@ -8082,7 +8093,7 @@ Module: int
 What:   removed
 Rank:   minor
 [DESCRIPTION]
-The offset arguments for element constraints have been removed, as you can 
+The offset arguments for element constraints have been removed, as you can
 simply add dummy elements to the array to achieve the same effect.
 
 [ENTRY]
@@ -8090,7 +8101,7 @@ Module: set
 What:   removed
 Rank:   minor
 [DESCRIPTION]
-The offset arguments for selection constraints have been removed, as you can 
+The offset arguments for selection constraints have been removed, as you can
 simply add dummy elements to the array to achieve the same effect.
 
 [ENTRY]
@@ -8098,9 +8109,9 @@ Module: other
 What:   new
 Rank:   major
 [DESCRIPTION]
-The serialization library now contains a registry of all the %Gecode post 
-functions. This makes interfacing to %Gecode much easier. The registry is 
-automatically generated from the post functions defined in gecode/int.hh and 
+The serialization library now contains a registry of all the %Gecode post
+functions. This makes interfacing to %Gecode much easier. The registry is
+automatically generated from the post functions defined in gecode/int.hh and
 gecode/set.hh.
 
 [ENTRY]
@@ -8108,12 +8119,12 @@ Module: kernel
 What:   change
 Rank:   minor
 [DESCRIPTION]
-Cleaned up reflection. Unreflection is now part of the kernel instead of the 
-serialization library. Branchings now provide a human-readable description of 
-a BranchingDesc. The name function of a Propagator has been renamed to ati 
-(actor type identifier). All reflection is now const where possible. 
-Unreflection of variables now checks dynamically that the variable types 
-match. Unreflection of propagators checks the number of arguments. A 
+Cleaned up reflection. Unreflection is now part of the kernel instead of the
+serialization library. Branchings now provide a human-readable description of
+a BranchingDesc. The name function of a Propagator has been renamed to ati
+(actor type identifier). All reflection is now const where possible.
+Unreflection of variables now checks dynamically that the variable types
+match. Unreflection of propagators checks the number of arguments. A
 tutorial-style section on reflection has been added to the documentation.
 
 [ENTRY]
@@ -8182,9 +8193,9 @@ Module: examples
 What:   new
 Rank:   minor
 [DESCRIPTION]
-Added an example that interprets a JavaScript program and runs a search of the 
-model that the program encodes. This is an example of how to use the 
-JavaScript interpreter. A simple JavaScript model for n-Queens has been added, 
+Added an example that interprets a JavaScript program and runs a search of the
+model that the program encodes. This is an example of how to use the
+JavaScript interpreter. A simple JavaScript model for n-Queens has been added,
 too.
 
 [ENTRY]
@@ -8192,9 +8203,9 @@ Module: kernel
 What:   new
 Rank:   minor
 [DESCRIPTION]
-A generic variable class has been added that can be used for interfacing. It 
-can store arbitrary %Gecode variables (e.g. IntVar and SetVar), and cast them 
-back using a run-time type check. The update, reflection, and output 
+A generic variable class has been added that can be used for interfacing. It
+can store arbitrary %Gecode variables (e.g. IntVar and SetVar), and cast them
+back using a run-time type check. The update, reflection, and output
 operations are implemented through the reflection registry.
 
 [ENTRY]
@@ -8244,10 +8255,10 @@ it got actually reimplemented):
  - Automatically generated stubs for variable implementations are directly
    inlined into the kernel. This improves performance, but more
    importantly, lifts some limits on the number of variables. Now, the
-   only limit is that the sum of the ceiling of the logarithms of the 
+   only limit is that the sum of the ceiling of the logarithms of the
    number of modification events of all variables does not exceed 32
    (as an estimate, the kernel now can handle around 10 to 16 variable
-   types). Moreover, if the need for more variable types arises this is 
+   types). Moreover, if the need for more variable types arises this is
    straightforward to do.
  - The addition of new variable types for users has been simplified.
  - The main propagation loop has been entirely rewritten (much much simpler).
@@ -8259,7 +8270,7 @@ it got actually reimplemented):
    do that already).
  - Variable implementations became smaller by one word. Now variable
    implementations are optimal in the sense that no additional memory
-   is needed for cloning or book-keeping, the memory required for 
+   is needed for cloning or book-keeping, the memory required for
    propagation is sufficient.
  - Spaces have lost some weight as memory for datastructures only used
    during cloning or propagation are shared (saves some 25% of memory
@@ -8286,7 +8297,7 @@ Module: gist
 What:   new
 Rank:   major
 [DESCRIPTION]
-The %Gecode Interactive Search Tool (Gist), a Qt-based graphical search 
+The %Gecode Interactive Search Tool (Gist), a Qt-based graphical search
 engine, is now part of the main %Gecode distribution. It is currently included
 as an experimental beta preview and may not be completely stable yet.
 
@@ -8392,7 +8403,7 @@ Module: kernel
 What:   bug
 Rank:   major
 [DESCRIPTION]
-Static initialization order was undefined, making reflection work unreliably. 
+Static initialization order was undefined, making reflection work unreliably.
 In particular, linking Gecode statically did not work.
 
 [ENTRY]
@@ -8400,7 +8411,7 @@ Module: int
 What:   bug
 Rank:   minor
 [DESCRIPTION]
-Initializing an IntVar with an empty IntSet did not throw the appropriate 
+Initializing an IntVar with an empty IntSet did not throw the appropriate
 exception but crashed.
 
 [ENTRY]
@@ -8408,7 +8419,7 @@ Module: kernel
 What:   bug
 Rank:   minor
 [DESCRIPTION]
-Exceptions did not have rtti information when compiled with gcc and 
+Exceptions did not have rtti information when compiled with gcc and
 visibility, which meant that they could not be caught.
 
 [ENTRY]
@@ -8424,7 +8435,7 @@ Module: kernel
 What:   change
 Rank:   minor
 [DESCRIPTION]
-The VarMapIter can now return both a specification and the actual VarBase* of 
+The VarMapIter can now return both a specification and the actual VarBase* of
 the currently iterated variable.
 
 [ENTRY]
@@ -8432,7 +8443,7 @@ Module: other
 What:   bug
 Rank:   minor
 [DESCRIPTION]
-Revived boost serialization.  The serialization functions will be compiled if 
+Revived boost serialization.  The serialization functions will be compiled if
 Gecode is configured with --with-boost.
 
 [ENTRY]
@@ -8486,7 +8497,7 @@ The highlights are:
 
 The features marked as experimental are all functional, but might
 be revised in the next releases.
- 
+
 As %Gecode 2.0.0 is a major release, you might have to adapt your
 programs:  \ref PageHowToChange_2 "How to Change to Gecode 2.0.0".
 
@@ -8687,7 +8698,7 @@ Module: kernel
 What:   new
 Rank:   major
 [DESCRIPTION]
-A reflection API has been added, which allows querying spaces 
+A reflection API has been added, which allows querying spaces
 about the variables and propagators they contain.
 
 [ENTRY]
@@ -8843,7 +8854,7 @@ Module:	int
 What:	new
 Rank:	minor
 [DESCRIPTION]
-Relaxed sharing restrictions for channel, in particular 
+Relaxed sharing restrictions for channel, in particular
 channel(this, x, x) is allowed.
 
 [ENTRY]
@@ -9154,7 +9165,7 @@ Module: int
 What:   change
 Rank:   minor
 [DESCRIPTION]
-Boolean variables cannot longer be initialized from an integer 
+Boolean variables cannot longer be initialized from an integer
 variable. If needed, a channel propagator must be posted (added).
 
 [ENTRY]
@@ -9238,9 +9249,9 @@ What:   bug
 Rank:   major
 Thanks: Rafael Meneses
 [DESCRIPTION]
-Branch&Bound search with ViewValBranchings (all standard branchings) together 
-with batch recomputation was severely broken. The problems ranged from wrong 
-search trees (missing solutions) to segmentation faults. The fix changes the 
+Branch&Bound search with ViewValBranchings (all standard branchings) together
+with batch recomputation was severely broken. The problems ranged from wrong
+search trees (missing solutions) to segmentation faults. The fix changes the
 way assigned variables are removed from the array in a ViewValBranching.
 
 [ENTRY]
@@ -9256,7 +9267,7 @@ Module: int
 What:   performance
 Rank:   minor
 [DESCRIPTION]
-Bounds-consistent distinct eliminates assigned variables more 
+Bounds-consistent distinct eliminates assigned variables more
 aggressively (can save up to 10% runtime in some cases).
 
 [ENTRY]
@@ -9353,7 +9364,7 @@ Rank:	minor
 [DESCRIPTION]
 New configure switches: --enable-audit to include audit code, which may
 contain expensive checks of internal invariants or alternative, checked
-implementations of critical parts of %Gecode. --enable-universal and 
+implementations of critical parts of %Gecode. --enable-universal and
 --with-sdk, to support building universal binaries on Mac OS X.
 
 [ENTRY]
@@ -9361,9 +9372,9 @@ Module: kernel
 What:	new
 Rank:	minor
 [DESCRIPTION]
-Variables can now be deallocated when the Space is deallocated (for example in 
-case of failure). This is important in case a variable implementation needs to 
-reference external resources. Deallocation can be switched on in the 
+Variables can now be deallocated when the Space is deallocated (for example in
+case of failure). This is important in case a variable implementation needs to
+reference external resources. Deallocation can be switched on in the
 high-level description used for generating the variable implementation.
 
 [ENTRY]
@@ -9372,7 +9383,7 @@ What:	bug
 Rank:	minor
 Thanks:	Rafael Meneses
 [DESCRIPTION]
-Under certain conditions (posting in a failed space), the post function 
+Under certain conditions (posting in a failed space), the post function
 returned uninitialized variables.
 
 [ENTRY]
@@ -9383,7 +9394,7 @@ Rank: 	major
 Variable implementations are now generated from a high-level
 description (taking care of all aspects relating to modification
 events and propagation conditions). While simplifying the
-implementation of new variable domains considerably, this also can, 
+implementation of new variable domains considerably, this also can,
 in lucky cases, deliver a speed-up of 5%.
 
 [ENTRY]
@@ -9799,21 +9810,21 @@ but a "dispose" member function that takes a home space as argument
 and must return the size of the actor.
 Important: this requires that dispose member functions from super-classes
 and class members are called explicitly!
-	
+
 [ENTRY]
 Module: kernel
 What:   new
 Rank:   minor
 [DESCRIPTION]
 Spaces can be queried for number of propagators and branchings.
-	
+
 [ENTRY]
 Module: search
 What:   new
 Rank:   minor
 [DESCRIPTION]
 Search engines can now be checked whether they have been stopped.
-	
+
 [ENTRY]
 Module: int
 What:   documentation
@@ -9821,7 +9832,7 @@ Rank:   minor
 Thanks:	Martin Mann
 [DESCRIPTION]
 Fixed bug in description of PC_INT_DOM.
-	
+
 [ENTRY]
 Module: other
 What:   change
@@ -9831,7 +9842,7 @@ Thanks:	Martin Mann
 Moved library source code into gecode subdirectory. Facilitates cleaner
 installation. Programs compiling against %Gecode now need to include
 e.g. "gecode/int.hh".
-	
+
 [ENTRY]
 Module: example
 What:   change
@@ -9849,7 +9860,7 @@ small fixes. Most notably, the test infrastructure has been extended to
 also check whether propagators correctly claim that they have computed
 a fixpoint (now all invariants a propagator must obey in %Gecode are covered
 by the test infrastructure). This has lead to many small fixes.
-	
+
 [ENTRY]
 Module: other
 What:   bug
@@ -9859,7 +9870,7 @@ Thanks: Kari Pahula
 [DESCRIPTION]
 Added a configure switch --enable-doc-dot. If enabled, this checks for
 presence of the dot tool (used for generating graphs in the documentation)
-	
+
 [ENTRY]
 Module: example
 What:   new
@@ -9872,7 +9883,7 @@ Module: minimodel
 What:   new
 Rank:   minor
 [DESCRIPTION]
-Added functions returning variables for arithmetic 
+Added functions returning variables for arithmetic
 (min, max, abs, mult, plus, minus).
 
 [ENTRY]
@@ -9880,16 +9891,16 @@ Module: int
 What:   change
 Rank:   minor
 [DESCRIPTION]
-Support for shared views has been removed in 
-sortedness propagator and in the propagator 
-for global cardinality with fixed cardinalities. 
+Support for shared views has been removed in
+sortedness propagator and in the propagator
+for global cardinality with fixed cardinalities.
 
 [ENTRY]
 Module: int
 What:   bug
 Rank:   minor
 [DESCRIPTION]
-Fixed bug in fixpoint detection of sortedness and 
+Fixed bug in fixpoint detection of sortedness and
 global cardinality propagator.
 
 [ENTRY]
@@ -9963,7 +9974,7 @@ Module: int
 What:   bug
 Rank:   minor
 [DESCRIPTION]
-Fixed bug in fixpoint detection of bounds-consistent 
+Fixed bug in fixpoint detection of bounds-consistent
 element for variables propagator.
 
 [ENTRY]
@@ -10005,7 +10016,7 @@ Rank:   major
 Thanks: Jean-Christophe Godart
 [DESCRIPTION]
 Fixed indexing bug in SupportSet (part of the domain consistent linear
-equation propagator). 
+equation propagator).
 
 [ENTRY]
 Module: int

--- a/changelog.in
+++ b/changelog.in
@@ -322,7 +322,6 @@ Rank:   minor
 For action-based branching heuristics, one can now define whether
 failure, propagation, or both should be considered.
 
-
 [RELEASE]
 Version: 6.2.0
 Date: 2019-04-12

--- a/changelog.in
+++ b/changelog.in
@@ -69,6 +69,17 @@ Date: 2020-??-??
 [DESCRIPTION]
 Let's see.
 
+
+[ENTRY]
+Module: kernel
+What:   change
+Rank:   minor
+[DESCRIPTION]
+Make the region pool thread local.
+[MORE]
+When running tests in parallel, having a shared pool for regions took too much
+time on macOS. This change makes the pool into a thread_local instead.
+
 [ENTRY]
 Module: kernel
 What:   change

--- a/configure
+++ b/configure
@@ -808,7 +808,6 @@ enable_gcov
 enable_thread
 with_freelist32_size_max
 with_freelist64_size_max
-enable_cpp11
 enable_gcc_visibility
 enable_doc_dot
 enable_doc_search
@@ -1470,7 +1469,6 @@ Optional Features:
   --enable-profile        build with profiling information [default=no]
   --enable-gcov           build with gcov support [default=no]
   --enable-thread         build with multi-threading support [default=yes]
-  --enable-cpp11          compile for C++11 standard [default=yes]
   --enable-gcc-visibility use gcc visibility attributes [default=yes]
   --enable-doc-dot        enable graphs in documentation [default=yes]
   --enable-doc-search     enable documentation search engine [default=no]
@@ -7322,13 +7320,6 @@ ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
 
    fi
 
-  # Check whether --enable-cpp11 was given.
-if test "${enable_cpp11+set}" = set; then :
-  enableval=$enable_cpp11;
-fi
-
-  if test "${enable_cpp11:-yes}" = "yes"; then
-
    if test "${ac_cv_cxx_compiler_vendor}" = "microsoft"; then
      { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether ${CXX} accepts -std=c++11" >&5
 $as_echo_n "checking whether ${CXX} accepts -std=c++11... " >&6; }
@@ -7442,12 +7433,6 @@ ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ex
 ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
 
    fi
-  else
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether to compile for C++11 standard" >&5
-$as_echo_n "checking whether to compile for C++11 standard... " >&6; }
-    { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-  fi
 
   if test "${ac_cv_cxx_compiler_vendor}" = "microsoft"; then
      { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether ${CXX} accepts -ggdb" >&5
@@ -10412,13 +10397,6 @@ ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
 
    fi
 
-  # Check whether --enable-cpp11 was given.
-if test "${enable_cpp11+set}" = set; then :
-  enableval=$enable_cpp11;
-fi
-
-  if test "${enable_cpp11:-yes}" = "yes"; then
-
    if test "${ac_cv_cxx_compiler_vendor}" = "microsoft"; then
      { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether ${CXX} accepts -std=c++11" >&5
 $as_echo_n "checking whether ${CXX} accepts -std=c++11... " >&6; }
@@ -10532,12 +10510,6 @@ ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ex
 ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
 
    fi
-  else
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether to compile for C++11 standard" >&5
-$as_echo_n "checking whether to compile for C++11 standard... " >&6; }
-    { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-  fi
 
   if test "${ac_cv_cxx_compiler_vendor}" = "microsoft"; then
      { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether ${CXX} accepts -ggdb" >&5

--- a/gecode.m4
+++ b/gecode.m4
@@ -671,16 +671,7 @@ AC_DEFUN([AC_GECODE_GCC_GENERAL_SWITCHES],
   AC_GECODE_CHECK_COMPILERFLAG([-Wall])
   AC_GECODE_CHECK_COMPILERFLAG([-Wno-unknown-pragmas])
   AC_GECODE_CHECK_COMPILERFLAG([-pipe])
-
-  AC_ARG_ENABLE([cpp11],
-       AC_HELP_STRING([--enable-cpp11],
-         [compile for C++11 standard @<:@default=yes@:>@]))
-  if test "${enable_cpp11:-yes}" = "yes"; then
-    AC_GECODE_CHECK_COMPILERFLAG([-std=c++11])
-  else
-    AC_MSG_CHECKING(whether to compile for C++11 standard)
-    AC_MSG_RESULT(no)
-  fi
+  AC_GECODE_CHECK_COMPILERFLAG([-std=c++11])
 
   AC_GECODE_CHECK_CXXFLAG(-ggdb,
      AC_GECODE_ADD_TO_COMPILERFLAGS(-ggdb),

--- a/gecode/kernel/gpi.hpp
+++ b/gecode/kernel/gpi.hpp
@@ -72,7 +72,7 @@ namespace Gecode { namespace Kernel {
     /// The inverse decay factor
     double invd;
     /// Next free propagator id
-    unsigned int npid;
+    std::atomic<unsigned int> npid;
     /// Whether to unshare
     bool us;
     /// The first block
@@ -143,11 +143,7 @@ namespace Gecode { namespace Kernel {
 
   forceinline unsigned int
   GPI::pid(void) const {
-    unsigned int p;
-    const_cast<GPI&>(*this).m.acquire();
-    p = npid;
-    const_cast<GPI&>(*this).m.release();
-    return p;
+    return npid.load(std::memory_order_acquire);
   }
 
   forceinline bool
@@ -189,8 +185,8 @@ namespace Gecode { namespace Kernel {
       n->next = b; b = n;
     }
     c = &b->info[--b->free];
-    c->init(npid++,gid);
     m.release();
+    c->init(npid.fetch_add(std::memory_order::memory_order_seq_cst),gid);
     return c;
   }
 

--- a/gecode/kernel/memory/region.cpp
+++ b/gecode/kernel/memory/region.cpp
@@ -76,7 +76,7 @@ namespace Gecode {
   }
 
   Region::Pool& Region::pool(void) {
-    static Region::Pool _p;
+    thread_local static Region::Pool _p;
     return _p;
   }
 

--- a/gecode/support/random.hpp
+++ b/gecode/support/random.hpp
@@ -51,8 +51,6 @@ namespace Gecode { namespace Support {
     static const unsigned int max = 1UL<<31;
     /// Current seed value
     unsigned int s;
-    /// Generate next number in series
-    unsigned int next(void);
     /// Returns a random integer from the interval \f$[0\ldots n)\f$
     unsigned int u(unsigned int n);
     /// Returns a random integer from the interval \f$[0\ldots n)\f$
@@ -64,6 +62,8 @@ namespace Gecode { namespace Support {
     LinearCongruentialGenerator(unsigned int s = 1);
     /// Return current seed
     unsigned int seed(void) const;
+    /// Generate next number in series
+    unsigned int next(void);
     /// Returns a random integer from the interval \f$[0\ldots n)\f$
     template<class Type>
     Type operator ()(Type n);

--- a/test/afc.cpp
+++ b/test/afc.cpp
@@ -69,14 +69,14 @@ namespace Test {
     static const int n = 16;
     /// Return random index of non-null space
     int space(TestSpace* s[]) {
-      int i = rand(n);
+      int i = _rand(n);
       while (s[i] == nullptr)
         i = (i+1) % n;
       return i;
     }
     /// Return random index
     int index(void) {
-      return rand(n);
+      return _rand(n);
     }
   public:
     /// Initialize test
@@ -93,7 +93,7 @@ namespace Test {
       s[0] = new TestSpace;
 
       for (int o=n_ops; o--; )
-        switch (rand(3)) {
+        switch (_rand(3)) {
         case 0:
           // clone space
           {

--- a/test/array.cpp
+++ b/test/array.cpp
@@ -205,7 +205,7 @@ namespace Test {
       // Space for the test
       TestSpace s;
       // VarArray for the test
-      Array a(s,rand(n));
+      Array a(s,_rand(n));
       // Run the iterator test
       return runTestForArray(a);
     }
@@ -226,7 +226,7 @@ namespace Test {
       // Space for the test
       TestSpace s;
       // VarArray for the test
-      Array a(rand(n));
+      Array a(_rand(n));
       // Run the iterator test
       return runTestForArray(a);
     }
@@ -247,7 +247,7 @@ namespace Test {
       // Space for the test
       TestSpace s;
       // VarArray for the test
-      Array a(s,rand(n));
+      Array a(s,_rand(n));
       // Run the iterator test
       return runTestForArray(a);
     }
@@ -266,7 +266,7 @@ namespace Test {
     /// Perform actual tests
     bool run(void) {
       // SharedArray for the test
-      Array a(rand(n));
+      Array a(_rand(n));
       // Run the iterator test
       return runTestForArray(a);
     }

--- a/test/array.cpp
+++ b/test/array.cpp
@@ -38,19 +38,23 @@
 
 /// Check the test result and handle failed test
 #define CHECK_TEST(T,M)                                         \
+do {                                                            \
 if (opt.log)                                                    \
   olog << ind(3) << "Check: " << (M) << std::endl;              \
 if (!(T)) {                                                     \
-  problem = (M); goto failed;                         \
-}
+  problem = (M); goto failed;                                   \
+}                                                               \
+} while (false)
 
 /// Start new test
 #define START_TEST(T)                                           \
+do {                                                            \
   if (opt.log) {                                                \
      olog.str("");                                              \
      olog << ind(2) << "Testing: " << (T) << std::endl;         \
   }                                                             \
-  test = (T);
+  test = (T);                                                   \
+} while (false)
 
 namespace Test {
 

--- a/test/assign.cpp
+++ b/test/assign.cpp
@@ -182,8 +182,8 @@ namespace Test { namespace Assign {
     for (int val = 0; val<n_int_assign; val++) {
       IntTestSpace* clone = static_cast<IntTestSpace*>(root->clone());
       Gecode::Search::Options o;
-      o.a_d = Base::rand(10);
-      o.c_d = Base::rand(10);
+      o.a_d = _rand(10);
+      o.c_d = _rand(10);
 
       Rnd r(1);
       IntAssign ia;
@@ -231,8 +231,8 @@ namespace Test { namespace Assign {
     for (int val = n_bool_assign; val--; ) {
       BoolTestSpace* clone = static_cast<BoolTestSpace*>(root->clone());
       Gecode::Search::Options o;
-      o.a_d = Base::rand(10);
-      o.c_d = Base::rand(10);
+      o.a_d = _rand(10);
+      o.c_d = _rand(10);
       Rnd r(1);
       BoolAssign ia;
       switch (val) {
@@ -307,8 +307,8 @@ namespace Test { namespace Assign {
     for (int val = n_set_assign; val--; ) {
       SetTestSpace* clone = static_cast<SetTestSpace*>(root->clone());
       Gecode::Search::Options o;
-      o.a_d = Base::rand(10);
-      o.c_d = Base::rand(10);
+      o.a_d = _rand(10);
+      o.c_d = _rand(10);
 
       Rnd r(1);
 
@@ -388,8 +388,8 @@ namespace Test { namespace Assign {
     for (int val = n_float_assign; val--; ) {
       FloatTestSpace* clone = static_cast<FloatTestSpace*>(root->clone());
       Gecode::Search::Options o;
-      o.a_d = Base::rand(10);
-      o.c_d = Base::rand(10);
+      o.a_d = _rand(10);
+      o.c_d = _rand(10);
 
       Rnd r(1);
 

--- a/test/branch.cpp
+++ b/test/branch.cpp
@@ -409,9 +409,9 @@ namespace Test { namespace Branch {
 
   /// Find number of solutions
   template<class TestSpace>
-  int solutions(TestSpace* c, Gecode::Search::Options& o, int maxNbSol = -1) {
-    o.a_d = Base::rand(10);
-    o.c_d = Base::rand(10);
+  int solutions(TestSpace* c, Gecode::Search::Options& o, Gecode::Support::RandomGenerator& rand, int maxNbSol = -1) {
+    o.a_d = rand(10);
+    o.c_d = rand(10);
     Gecode::DFS<TestSpace> e_s(c, o);
     delete c;
 
@@ -552,7 +552,7 @@ namespace Test { namespace Branch {
             case 30: ivbb = INT_VAR_REGRET_MAX_MAX(&tbl); break;
             }
 
-            switch (Base::rand(9U)) {
+            switch (_rand(9U)) {
             case 0U:
               branch(*c, c->x, ivba, ivb); break;
             case 1U:
@@ -575,7 +575,7 @@ namespace Test { namespace Branch {
 
           }
           Gecode::Search::Options o;
-          results[solutions(c,o)].push_back
+          results[solutions(c, o, _rand)].push_back
             (RunInfo(int_var_branch_name[vara],
                      int_var_branch_name[varb],
                      int_val_branch_name[val],
@@ -682,7 +682,7 @@ namespace Test { namespace Branch {
             case 12: bvbb = BOOL_VAR_CHB_MAX(bcb,&tbl); break;
             }
 
-            switch (Base::rand(9U)) {
+            switch (_rand(9U)) {
             case 0U:
               branch(*c, c->x, bvba, bvb); break;
             case 1U:
@@ -705,7 +705,7 @@ namespace Test { namespace Branch {
 
           }
           Gecode::Search::Options o;
-          results[solutions(c,o)].push_back
+          results[solutions(c, o, _rand)].push_back
             (RunInfo(int_var_branch_name[vara],
                      int_var_branch_name[varb],
                      int_val_branch_name[val],
@@ -844,7 +844,7 @@ namespace Test { namespace Branch {
             case 26: svbb = SET_VAR_CHB_SIZE_MAX(scb,&tbl); break;
             }
 
-            switch (Base::rand(9U)) {
+            switch (_rand(9U)) {
             case 0U:
               branch(*c, c->x, svba, svb); break;
             case 1U:
@@ -867,7 +867,7 @@ namespace Test { namespace Branch {
 
           }
           Gecode::Search::Options o;
-          results[solutions(c,o)].push_back
+          results[solutions(c, o, _rand)].push_back
             (RunInfo(set_var_branch_name[vara],
                      set_var_branch_name[varb],
                      set_val_branch_name[val],
@@ -1001,7 +1001,7 @@ namespace Test { namespace Branch {
             case 26: fvbb = FLOAT_VAR_CHB_SIZE_MAX(fcb,&tbl); break;
             }
 
-            switch (Base::rand(9U)) {
+            switch (_rand(9U)) {
             case 0U:
               branch(*c, c->x, fvba, fvb); break;
             case 1U:
@@ -1024,7 +1024,7 @@ namespace Test { namespace Branch {
 
           }
           Gecode::Search::Options o;
-          results[solutions(c,o,nbSols)].push_back
+          results[solutions(c, o, _rand, nbSols)].push_back
             (RunInfo(float_var_branch_name[vara],
                      float_var_branch_name[varb],
                      float_val_branch_name[val],

--- a/test/float.cpp
+++ b/test/float.cpp
@@ -309,16 +309,16 @@ namespace Test { namespace Float {
     for (int j=x.size(); j--; ) {
       if (!x[j].assigned() && (x[j].size() > x[i].size())) i = j;
     }
-    Rounding r;
+    Rounding rounding;
     if (cutDirections[i]) {
-      FloatNum m = r.div_up(r.add_up(x[i].min(),x[i].max()),2);
+      FloatNum m = rounding.div_up(rounding.add_up(x[i].min(), x[i].max()), 2);
       FloatNum n = nextafter(x[i].min(), x[i].max());
       if (m > n)
         rel(i, FRT_LQ, m);
       else
         rel(i, FRT_LQ, n);
     } else {
-      FloatNum m = r.div_down(r.add_down(x[i].min(),x[i].max()),2);
+      FloatNum m = rounding.div_down(rounding.add_down(x[i].min(), x[i].max()), 2);
       FloatNum n = nextafter(x[i].max(), x[i].min());
       if (m < n)
         rel(i, FRT_GQ, m);
@@ -392,8 +392,8 @@ namespace Test { namespace Float {
       if (c->failed()) {
         delete c; return false;
       }
-      for (int i=x.size(); i--; )
-        if (x[i].size() != c->x[i].size()) {
+      for (int j=x.size(); j--; )
+        if (x[j].size() != c->x[j].size()) {
           delete c; return false;
         }
       if (reified && (r.var().size() != c->r.var().size())) {
@@ -447,19 +447,23 @@ namespace Test { namespace Float {
 
   /// Check the test result and handle failed test
 #define CHECK_TEST(T,M)                                         \
+do {                                                            \
 if (opt.log)                                                    \
   olog << ind(3) << "Check: " << (M) << std::endl;              \
 if (!(T)) {                                                     \
   problem = (M); delete s; goto failed;                         \
-}
+}                                                               \
+} while (false)
 
   /// Start new test
 #define START_TEST(T)                                           \
+do {                                                            \
   if (opt.log) {                                                \
      olog.str("");                                              \
      olog << ind(2) << "Testing: " << (T) << std::endl;         \
   }                                                             \
-  test = (T);
+  test = (T);                                                   \
+} while (false)
 
   bool
   Test::ignore(const Assignment&) const {

--- a/test/float.cpp
+++ b/test/float.cpp
@@ -64,7 +64,7 @@ namespace Test { namespace Float {
    *
    */
   void
-  ExtAssignment::next(Gecode::Support::RandomGenerator& rand) {
+  ExtAssignment::next(Gecode::Support::RandomGenerator&) {
     using namespace Gecode;
     assert(n > 1);
     int i = n-2;

--- a/test/float.cpp
+++ b/test/float.cpp
@@ -47,7 +47,7 @@ namespace Test { namespace Float {
    *
    */
   void
-  CpltAssignment::next(void) {
+  CpltAssignment::next(Gecode::Support::RandomGenerator&) {
     using namespace Gecode;
     int i = n-1;
     while (true) {
@@ -64,7 +64,7 @@ namespace Test { namespace Float {
    *
    */
   void
-  ExtAssignment::next(void) {
+  ExtAssignment::next(Gecode::Support::RandomGenerator& rand) {
     using namespace Gecode;
     assert(n > 1);
     int i = n-2;
@@ -86,9 +86,9 @@ namespace Test { namespace Float {
    *
    */
   void
-  RandomAssignment::next(void) {
+  RandomAssignment::next(Gecode::Support::RandomGenerator& rand) {
     for (int i = n; i--; )
-      vals[i]=randval();
+      vals[i]= randval(rand);
     a--;
   }
 
@@ -105,7 +105,7 @@ operator<<(std::ostream& os, const Test::Float::Assignment& a) {
 
 namespace Test { namespace Float {
 
-  Gecode::FloatNum randFValDown(Gecode::FloatNum l, Gecode::FloatNum u) {
+  Gecode::FloatNum randFValDown(Gecode::FloatNum l, Gecode::FloatNum u, Gecode::Support::RandomGenerator& rand) {
     using namespace Gecode;
     using namespace Gecode::Float;
     Rounding r;
@@ -114,7 +114,7 @@ namespace Test { namespace Float {
         l,
         r.mul_down(
                    r.div_down(
-                              Base::rand(static_cast<unsigned int>(Int::Limits::max)),
+                              rand(static_cast<unsigned int>(Int::Limits::max)),
                               static_cast<FloatNum>(Int::Limits::max)
                               ),
                    r.sub_down(u,l)
@@ -122,7 +122,7 @@ namespace Test { namespace Float {
         );
   }
 
-  Gecode::FloatNum randFValUp(Gecode::FloatNum l, Gecode::FloatNum u) {
+  Gecode::FloatNum randFValUp(Gecode::FloatNum l, Gecode::FloatNum u, Gecode::Support::RandomGenerator& rand) {
     using namespace Gecode;
     using namespace Gecode::Float;
     Rounding r;
@@ -131,7 +131,7 @@ namespace Test { namespace Float {
         u,
         r.mul_down(
           r.div_down(
-            Base::rand(static_cast<unsigned int>(Int::Limits::max)),
+            rand(static_cast<unsigned int>(Int::Limits::max)),
             static_cast<FloatNum>(Int::Limits::max)
           ),
           r.sub_down(u,l)
@@ -267,9 +267,9 @@ namespace Test { namespace Float {
   }
 
   void
-  TestSpace::assign(const Assignment& a, MaybeType& sol, bool skip) {
+  TestSpace::assign(const Assignment& a, MaybeType& sol, bool skip, Gecode::Support::RandomGenerator& rand) {
     using namespace Gecode;
-    int i = skip ? static_cast<int>(Base::rand(a.size())) : -1;
+    int i = skip ? static_cast<int>(rand(a.size())) : -1;
 
     for (int j=a.size(); j--; )
       if (i != j) {
@@ -279,20 +279,20 @@ namespace Test { namespace Float {
           return;
         }
         rel(j, FRT_EQ, a[j]);
-        if (Base::fixpoint() && failed())
+        if (Base::fixpoint(rand) && failed())
           return;
       }
   }
 
   void
-  TestSpace::bound(void) {
+  TestSpace::bound(Gecode::Support::RandomGenerator& rand) {
     using namespace Gecode;
     // Select variable to be assigned
-    int i = Base::rand(x.size());
+    int i = rand(x.size());
     while (x[i].assigned()) {
       i = (i+1) % x.size();
     }
-    bool min = Base::rand(2);
+    bool min = rand(2);
     if (min)
       rel(i, FRT_LQ, nextafter(x[i].min(), x[i].max()));
     else
@@ -329,43 +329,43 @@ namespace Test { namespace Float {
   }
 
   void
-  TestSpace::prune(int i) {
+  TestSpace::prune(int i, Gecode::Support::RandomGenerator& rand) {
     using namespace Gecode;
     // Prune values
-    if (Base::rand(2) && !x[i].assigned()) {
-      Gecode::FloatNum v=randFValUp(x[i].min(),x[i].max());
+    if (rand(2) && !x[i].assigned()) {
+      Gecode::FloatNum v= randFValUp(x[i].min(), x[i].max(), rand);
       assert((v >= x[i].min()) && (v <= x[i].max()));
       rel(i, Gecode::FRT_LQ, v);
     }
-    if (Base::rand(2) && !x[i].assigned()) {
-      Gecode::FloatNum v=randFValDown(x[i].min(),x[i].max());
+    if (rand(2) && !x[i].assigned()) {
+      Gecode::FloatNum v= randFValDown(x[i].min(), x[i].max(), rand);
       assert((v <= x[i].max()) && (v >= x[i].min()));
       rel(i, Gecode::FRT_GQ, v);
     }
   }
 
   void
-  TestSpace::prune(void) {
+  TestSpace::prune(Gecode::Support::RandomGenerator& rand) {
     using namespace Gecode;
     // Select variable to be pruned
-    int i = Base::rand(x.size());
+    int i = rand(x.size());
     while (x[i].assigned()) {
       i = (i+1) % x.size();
     }
-    prune(i);
+    prune(i, rand);
   }
 
   bool
-  TestSpace::prune(const Assignment& a, bool testfix) {
+  TestSpace::prune(const Assignment& a, bool testfix, Gecode::Support::RandomGenerator& rand) {
     // Select variable to be pruned
-    int i = Base::rand(x.size());
+    int i = rand(x.size());
     while (x[i].assigned())
       i = (i+1) % x.size();
     // Select mode for pruning
-    switch (Base::rand(2)) {
+    switch (rand(2)) {
     case 0:
       if (a[i].max() < x[i].max()) {
-        Gecode::FloatNum v=randFValDown(a[i].max(),x[i].max());
+        Gecode::FloatNum v= randFValDown(a[i].max(), x[i].max(), rand);
         if (v==x[i].max())
           v = a[i].max();
         assert((v >= a[i].max()) && (v <= x[i].max()));
@@ -374,7 +374,7 @@ namespace Test { namespace Float {
       break;
     case 1:
       if (a[i].min() > x[i].min()) {
-        Gecode::FloatNum v=randFValUp(x[i].min(),a[i].min());
+        Gecode::FloatNum v= randFValUp(x[i].min(), a[i].min(), rand);
         if (v==x[i].min())
           v = a[i].min();
         assert((v <= a[i].min()) && (v >= x[i].min()));
@@ -382,7 +382,7 @@ namespace Test { namespace Float {
       }
       break;
     }
-    if (Base::fixpoint()) {
+    if (Base::fixpoint(rand)) {
       if (failed() || !testfix)
         return true;
       TestSpace* c = static_cast<TestSpace*>(clone());
@@ -422,9 +422,9 @@ namespace Test { namespace Float {
     case CPLT_ASSIGNMENT:
       return new CpltAssignment(arity,dom,step);
     case RANDOM_ASSIGNMENT:
-      return new RandomAssignment(arity,dom,step);
+      return new RandomAssignment(arity, dom, step, _rand);
     case EXTEND_ASSIGNMENT:
-      return new ExtAssignment(arity,dom,step,this);
+      return new ExtAssignment(arity, dom, step, this, _rand);
     default :
       GECODE_NEVER;
     }
@@ -507,7 +507,7 @@ do {                                                            \
         TestSpace* s = new TestSpace(arity,dom,step,this);
         TestSpace* sc = nullptr;
         s->post();
-        switch (Base::rand(2)) {
+        switch (_rand(2)) {
           case 0:
             if (opt.log)
               olog << ind(3) << "No copy" << std::endl;
@@ -525,7 +525,7 @@ do {                                                            \
             break;
           default: assert(false);
         }
-        sc->assign(a,sol);
+        sc->assign(a, sol, false, _rand);
         if (sol == MT_TRUE) {
           CHECK_TEST(!sc->failed(), "Failed on solution");
           CHECK_TEST(subsumed(*sc), "No subsumption");
@@ -538,9 +538,9 @@ do {                                                            \
       {
         TestSpace* s = new TestSpace(arity,dom,step,this);
         s->post();
-        s->assign(a,sol,true);
+        s->assign(a, sol, true, _rand);
         (void) s->failed();
-        s->assign(a,sol);
+        s->assign(a, sol, false, _rand);
         if (sol == MT_TRUE) {
           CHECK_TEST(!s->failed(), "Failed on solution");
           CHECK_TEST(subsumed(*s), "No subsumption");
@@ -555,7 +555,7 @@ do {                                                            \
         s->post();
         s->disable();
         s->enable();
-        s->assign(a,sol);
+        s->assign(a, sol, false, _rand);
         if (sol == MT_TRUE) {
           CHECK_TEST(!s->failed(), "Failed on solution");
           CHECK_TEST(subsumed(*s), "No subsumption");
@@ -570,9 +570,9 @@ do {                                                            \
         s->post();
         s->disable();
         s->enable();
-        s->assign(a,sol,true);
+        s->assign(a, sol, true, _rand);
         (void) s->failed();
-        s->assign(a,sol);
+        s->assign(a, sol, false, _rand);
         if (sol == MT_TRUE) {
           CHECK_TEST(!s->failed(), "Failed on solution");
           CHECK_TEST(subsumed(*s), "No subsumption");
@@ -584,7 +584,7 @@ do {                                                            \
       START_TEST("Assignment (before posting)");
       {
         TestSpace* s = new TestSpace(arity,dom,step,this);
-        s->assign(a,sol);
+        s->assign(a, sol, false, _rand);
         s->post();
         if (sol == MT_TRUE) {
           CHECK_TEST(!s->failed(), "Failed on solution");
@@ -597,10 +597,10 @@ do {                                                            \
       START_TEST("Partial assignment (before posting)");
       {
         TestSpace* s = new TestSpace(arity,dom,step,this);
-        s->assign(a,sol,true);
+        s->assign(a, sol, true, _rand);
         s->post();
         (void) s->failed();
-        s->assign(a,sol);
+        s->assign(a, sol, false, _rand);
         if (sol == MT_TRUE) {
           CHECK_TEST(!s->failed(), "Failed on solution");
           CHECK_TEST(subsumed(*s), "No subsumption");
@@ -614,12 +614,12 @@ do {                                                            \
         TestSpace* s = new TestSpace(arity,dom,step,this);
         s->post();
         while (!s->failed() && !s->assigned() && !s->matchAssignment(a))
-          if (!s->prune(a,testfix)) {
+          if (!s->prune(a, testfix, _rand)) {
             problem = "No fixpoint";
             delete s;
             goto failed;
           }
-        s->assign(a,sol);
+        s->assign(a, sol, false, _rand);
         if (sol == MT_TRUE) {
           CHECK_TEST(!s->failed(), "Failed on solution");
           CHECK_TEST(subsumed(*s), "No subsumption");
@@ -634,7 +634,7 @@ do {                                                            \
           TestSpace* s = new TestSpace(arity,dom,step,this,RM_EQV);
           s->post();
           s->rel(sol == MT_TRUE);
-          s->assign(a,sol);
+          s->assign(a, sol, false, _rand);
           CHECK_TEST(!s->failed(), "Failed");
           CHECK_TEST(subsumed(*s), "No subsumption");
           delete s;
@@ -644,7 +644,7 @@ do {                                                            \
           TestSpace* s = new TestSpace(arity,dom,step,this,RM_IMP);
           s->post();
           s->rel(sol == MT_TRUE);
-          s->assign(a,sol);
+          s->assign(a, sol, false, _rand);
           CHECK_TEST(!s->failed(), "Failed");
           CHECK_TEST(subsumed(*s), "No subsumption");
           delete s;
@@ -654,7 +654,7 @@ do {                                                            \
           TestSpace* s = new TestSpace(arity,dom,step,this,RM_PMI);
           s->post();
           s->rel(sol == MT_TRUE);
-          s->assign(a,sol);
+          s->assign(a, sol, false, _rand);
           CHECK_TEST(!s->failed(), "Failed");
           CHECK_TEST(subsumed(*s), "No subsumption");
           delete s;
@@ -664,7 +664,7 @@ do {                                                            \
           TestSpace* s = new TestSpace(arity,dom,step,this,RM_EQV);
           s->rel(sol == MT_TRUE);
           s->post();
-          s->assign(a,sol);
+          s->assign(a, sol, false, _rand);
           CHECK_TEST(!s->failed(), "Failed");
           CHECK_TEST(subsumed(*s), "No subsumption");
           delete s;
@@ -674,7 +674,7 @@ do {                                                            \
           TestSpace* s = new TestSpace(arity,dom,step,this,RM_IMP);
           s->rel(sol == MT_TRUE);
           s->post();
-          s->assign(a,sol);
+          s->assign(a, sol, false, _rand);
           CHECK_TEST(!s->failed(), "Failed");
           CHECK_TEST(subsumed(*s), "No subsumption");
           delete s;
@@ -684,7 +684,7 @@ do {                                                            \
           TestSpace* s = new TestSpace(arity,dom,step,this,RM_PMI);
           s->rel(sol == MT_TRUE);
           s->post();
-          s->assign(a,sol);
+          s->assign(a, sol, false, _rand);
           CHECK_TEST(!s->failed(), "Failed");
           CHECK_TEST(subsumed(*s), "No subsumption");
           delete s;
@@ -692,7 +692,7 @@ do {                                                            \
         if (eqv()) {
           START_TEST("Assignment reified (before posting, <=>)");
           TestSpace* s = new TestSpace(arity,dom,step,this,RM_EQV);
-          s->assign(a,sol);
+          s->assign(a, sol, false, _rand);
           s->post();
           CHECK_TEST(!s->failed(), "Failed");
           CHECK_TEST(subsumed(*s), "No subsumption");
@@ -708,7 +708,7 @@ do {                                                            \
         if (imp()) {
           START_TEST("Assignment reified (before posting, =>)");
           TestSpace* s = new TestSpace(arity,dom,step,this,RM_IMP);
-          s->assign(a,sol);
+          s->assign(a, sol, false, _rand);
           s->post();
           CHECK_TEST(!s->failed(), "Failed");
           CHECK_TEST(subsumed(*s), "No subsumption");
@@ -722,7 +722,7 @@ do {                                                            \
         if (pmi()) {
           START_TEST("Assignment reified (before posting, <=)");
           TestSpace* s = new TestSpace(arity,dom,step,this,RM_PMI);
-          s->assign(a,sol);
+          s->assign(a, sol, false, _rand);
           s->post();
           CHECK_TEST(!s->failed(), "Failed");
           CHECK_TEST(subsumed(*s), "No subsumption");
@@ -739,7 +739,7 @@ do {                                                            \
           START_TEST("Assignment reified (after posting, <=>)");
           TestSpace* s = new TestSpace(arity,dom,step,this,RM_EQV);
           s->post();
-          s->assign(a,sol);
+          s->assign(a, sol, false, _rand);
           CHECK_TEST(!s->failed(), "Failed");
           CHECK_TEST(subsumed(*s), "No subsumption");
           if (s->r.var().assigned()) {
@@ -755,7 +755,7 @@ do {                                                            \
           START_TEST("Assignment reified (after posting, =>)");
           TestSpace* s = new TestSpace(arity,dom,step,this,RM_IMP);
           s->post();
-          s->assign(a,sol);
+          s->assign(a, sol, false, _rand);
           CHECK_TEST(!s->failed(), "Failed");
           CHECK_TEST(subsumed(*s), "No subsumption");
           if (sol == MT_TRUE) {
@@ -769,7 +769,7 @@ do {                                                            \
           START_TEST("Assignment reified (after posting, <=)");
           TestSpace* s = new TestSpace(arity,dom,step,this,RM_PMI);
           s->post();
-          s->assign(a,sol);
+          s->assign(a, sol, false, _rand);
           CHECK_TEST(!s->failed(), "Failed");
           CHECK_TEST(subsumed(*s), "No subsumption");
           if (sol == MT_TRUE) {
@@ -787,7 +787,7 @@ do {                                                            \
           s->post();
           while (!s->failed() && !s->matchAssignment(a) &&
                  (!s->assigned() || !s->r.var().assigned()))
-            if (!s->prune(a,testfix)) {
+            if (!s->prune(a, testfix, _rand)) {
               problem = "No fixpoint";
               delete s;
               goto failed;
@@ -810,7 +810,7 @@ do {                                                            \
           while (!s->failed() && !s->matchAssignment(a) &&
                  (!s->assigned() || ((sol == MT_FALSE) &&
                                      !s->r.var().assigned())))
-            if (!s->prune(a,testfix)) {
+            if (!s->prune(a, testfix, _rand)) {
               problem = "No fixpoint";
               delete s;
               goto failed;
@@ -831,7 +831,7 @@ do {                                                            \
           while (!s->failed() && !s->matchAssignment(a) &&
                  (!s->assigned() || ((sol == MT_TRUE) &&
                                      !s->r.var().assigned())))
-            if (!s->prune(a,testfix)) {
+            if (!s->prune(a, testfix, _rand)) {
               problem = "No fixpoint";
               delete s;
               goto failed;
@@ -868,7 +868,7 @@ do {                                                            \
         }
       }
 
-      a.next();
+      a.next(_rand);
     }
 
     if (testsearch) {

--- a/test/float.cpp
+++ b/test/float.cpp
@@ -491,7 +491,7 @@ do {                                                            \
     Search::Options search_o;
     search_o.threads = 1;
     DFS<TestSpace> * e_s = new DFS<TestSpace>(search_s,search_o);
-    while (a()) {
+    while (a.has_more()) {
       MaybeType sol = solution(a);
       if (opt.log) {
         olog << ind(1) << "Assignment: " << a;
@@ -896,7 +896,7 @@ do {                                                            \
       olog << "FAILURE" << std::endl
            << ind(1) << "Test:       " << test << std::endl
            << ind(1) << "Problem:    " << problem << std::endl;
-    if (a() && opt.log)
+    if (a.has_more() && opt.log)
       olog << ind(1) << "Assignment: " << a << std::endl;
     delete ap;
     delete search_s;

--- a/test/float.cpp
+++ b/test/float.cpp
@@ -47,7 +47,7 @@ namespace Test { namespace Float {
    *
    */
   void
-  CpltAssignment::operator++(void) {
+  CpltAssignment::next(void) {
     using namespace Gecode;
     int i = n-1;
     while (true) {
@@ -64,7 +64,7 @@ namespace Test { namespace Float {
    *
    */
   void
-  ExtAssignment::operator++(void) {
+  ExtAssignment::next(void) {
     using namespace Gecode;
     assert(n > 1);
     int i = n-2;
@@ -86,7 +86,7 @@ namespace Test { namespace Float {
    *
    */
   void
-  RandomAssignment::operator++(void) {
+  RandomAssignment::next(void) {
     for (int i = n; i--; )
       vals[i]=randval();
     a--;
@@ -868,7 +868,7 @@ do {                                                            \
         }
       }
 
-      ++a;
+      a.next();
     }
 
     if (testsearch) {

--- a/test/float.hh
+++ b/test/float.hh
@@ -87,7 +87,7 @@ namespace Test {
       /// Test whether all assignments have been iterated
       virtual bool has_more(void) const = 0;
       /// Move to next assignment
-      virtual void next(void) = 0;
+      virtual void next(Gecode::Support::RandomGenerator& rand) = 0;
       /// Return value for variable \a i
       virtual Gecode::FloatVal operator[](int i) const = 0;
       /// Set assignment to value \a val for variable \a i
@@ -109,7 +109,7 @@ namespace Test {
       /// Test whether all assignments have been iterated
       virtual bool has_more(void) const;
       /// Move to next assignment
-      virtual void next(void);
+      virtual void next(Gecode::Support::RandomGenerator& rand);
       /// Return value for variable \a i
       virtual Gecode::FloatVal operator[](int i) const;
       /// Set assignment to value \a val for variable \a i
@@ -126,11 +126,12 @@ namespace Test {
       Gecode::FloatNum step; ///< Step for next assignment
     public:
       /// Initialize assignments for \a n variables and values \a d with step \a s
-      ExtAssignment(int n, const Gecode::FloatVal& d, Gecode::FloatNum s, const Test * pb);
+      ExtAssignment(int n, const Gecode::FloatVal& d, Gecode::FloatNum s, const Test* pb,
+                    Gecode::Support::RandomGenerator& rand);
       /// Test whether all assignments have been iterated
       virtual bool has_more(void) const;
       /// Move to next assignment
-      virtual void next(void);
+      virtual void next(Gecode::Support::RandomGenerator& rand);
       /// Return value for variable \a i
       virtual Gecode::FloatVal operator[](int i) const;
       /// Set assignment to value \a val for variable \a i
@@ -146,14 +147,14 @@ namespace Test {
       Gecode::FloatVal* vals; ///< The current values for the variables
       int  a;                 ///< How many assigments still to be generated
       /// Generate new value according to domain
-      Gecode::FloatNum randval(void);
+      Gecode::FloatNum randval(Gecode::Support::RandomGenerator& rand);
     public:
       /// Initialize for \a a assignments for \a n variables and values \a d
-      RandomAssignment(int n, const Gecode::FloatVal& d, int a);
+      RandomAssignment(int n, const Gecode::FloatVal& d, int a0, Gecode::Support::RandomGenerator& rand);
       /// Test whether all assignments have been iterated
       virtual bool has_more(void) const;
       /// Move to next assignment
-      virtual void next(void);
+      virtual void next(Gecode::Support::RandomGenerator& rand);
       /// Return value for variable \a i
       virtual Gecode::FloatVal operator[](int i) const;
       /// Set assignment to value \a val for variable \a i
@@ -216,19 +217,19 @@ namespace Test {
       /// Assign all (or all but one, if \a skip is true) variables to values in \a a
       /// If assignment of a variable is MT_MAYBE (if the two intervals are contiguous),
       /// \a sol is set to MT_MAYBE
-      void assign(const Assignment& a, MaybeType& sol, bool skip=false);
+      void assign(const Assignment& a, MaybeType& sol, bool skip, Gecode::Support::RandomGenerator& rand);
       /// Assing a random variable to a random bound
-      void bound(void);
+      void bound(Gecode::Support::RandomGenerator& rand);
       /// Cut the bigger variable to an half sized interval. It returns
       /// the new size of the cut interval. \a cutDirections gives the direction
       /// to follow (upper part or lower part of the interval).
       Gecode::FloatNum cut(int* cutDirections);
       /// Prune some random values from variable \a i
-      void prune(int i);
+      void prune(int i, Gecode::Support::RandomGenerator& rand);
       /// Prune some random values for some random variable
-      void prune(void);
+      void prune(Gecode::Support::RandomGenerator& rand);
       /// Prune values but not those in assignment \a a
-      bool prune(const Assignment& a, bool testfix);
+      bool prune(const Assignment& a, bool testfix, Gecode::Support::RandomGenerator& rand);
       /// Disable propagators in space and compute fixpoint (make all idle)
       void disable(void);
       /// Enable propagators in space

--- a/test/float.hh
+++ b/test/float.hh
@@ -85,7 +85,7 @@ namespace Test {
       /// Initialize assignments for \a n0 variables and values \a d0
       Assignment(int n0, const Gecode::FloatVal& d0);
       /// Test whether all assignments have been iterated
-      virtual bool operator()(void) const = 0;
+      virtual bool has_more(void) const = 0;
       /// Move to next assignment
       virtual void next(void) = 0;
       /// Return value for variable \a i
@@ -107,7 +107,7 @@ namespace Test {
       /// Initialize assignments for \a n variables and values \a d with step \a s
       CpltAssignment(int n, const Gecode::FloatVal& d, Gecode::FloatNum s);
       /// Test whether all assignments have been iterated
-      virtual bool operator()(void) const;
+      virtual bool has_more(void) const;
       /// Move to next assignment
       virtual void next(void);
       /// Return value for variable \a i
@@ -128,7 +128,7 @@ namespace Test {
       /// Initialize assignments for \a n variables and values \a d with step \a s
       ExtAssignment(int n, const Gecode::FloatVal& d, Gecode::FloatNum s, const Test * pb);
       /// Test whether all assignments have been iterated
-      virtual bool operator()(void) const;
+      virtual bool has_more(void) const;
       /// Move to next assignment
       virtual void next(void);
       /// Return value for variable \a i
@@ -151,7 +151,7 @@ namespace Test {
       /// Initialize for \a a assignments for \a n variables and values \a d
       RandomAssignment(int n, const Gecode::FloatVal& d, int a);
       /// Test whether all assignments have been iterated
-      virtual bool operator()(void) const;
+      virtual bool has_more(void) const;
       /// Move to next assignment
       virtual void next(void);
       /// Return value for variable \a i

--- a/test/float.hh
+++ b/test/float.hh
@@ -87,7 +87,7 @@ namespace Test {
       /// Test whether all assignments have been iterated
       virtual bool operator()(void) const = 0;
       /// Move to next assignment
-      virtual void operator++(void) = 0;
+      virtual void next(void) = 0;
       /// Return value for variable \a i
       virtual Gecode::FloatVal operator[](int i) const = 0;
       /// Set assignment to value \a val for variable \a i
@@ -109,7 +109,7 @@ namespace Test {
       /// Test whether all assignments have been iterated
       virtual bool operator()(void) const;
       /// Move to next assignment
-      virtual void operator++(void);
+      virtual void next(void);
       /// Return value for variable \a i
       virtual Gecode::FloatVal operator[](int i) const;
       /// Set assignment to value \a val for variable \a i
@@ -130,7 +130,7 @@ namespace Test {
       /// Test whether all assignments have been iterated
       virtual bool operator()(void) const;
       /// Move to next assignment
-      virtual void operator++(void);
+      virtual void next(void);
       /// Return value for variable \a i
       virtual Gecode::FloatVal operator[](int i) const;
       /// Set assignment to value \a val for variable \a i
@@ -153,7 +153,7 @@ namespace Test {
       /// Test whether all assignments have been iterated
       virtual bool operator()(void) const;
       /// Move to next assignment
-      virtual void operator++(void);
+      virtual void next(void);
       /// Return value for variable \a i
       virtual Gecode::FloatVal operator[](int i) const;
       /// Set assignment to value \a val for variable \a i

--- a/test/float.hpp
+++ b/test/float.hpp
@@ -87,7 +87,7 @@ namespace Test { namespace Float {
     using namespace Gecode;
     for (int i=n-1; i--; )
       dsv[i] = FloatVal(d.min(),nextafter(d.min(),d.max()));
-    ++(*this);
+    (*this).next();
   }
   inline bool
   ExtAssignment::operator()(void) const {

--- a/test/float.hpp
+++ b/test/float.hpp
@@ -80,14 +80,15 @@ namespace Test { namespace Float {
   }
 
   inline
-  ExtAssignment::ExtAssignment(int n, const Gecode::FloatVal& d, Gecode::FloatNum s, const Test * pb)
+  ExtAssignment::ExtAssignment(int n, const Gecode::FloatVal& d, Gecode::FloatNum s, const Test* pb,
+                               Gecode::Support::RandomGenerator& rand)
   : Assignment(n,d),curPb(pb),
   dsv(new Gecode::FloatVal[static_cast<unsigned int>(n)]),
   step(s) {
     using namespace Gecode;
     for (int i=n-1; i--; )
       dsv[i] = FloatVal(d.min(),nextafter(d.min(),d.max()));
-    (*this).next();
+    (*this).next(rand);
   }
   inline bool
   ExtAssignment::has_more() const {
@@ -109,7 +110,7 @@ namespace Test { namespace Float {
   }
 
   forceinline Gecode::FloatNum
-  RandomAssignment::randval(void) {
+  RandomAssignment::randval(Gecode::Support::RandomGenerator& rand) {
     using namespace Gecode;
     using namespace Gecode::Float;
     Rounding r;
@@ -118,7 +119,7 @@ namespace Test { namespace Float {
         d.min(),
         r.mul_down(
           r.div_down(
-            Base::rand(static_cast<unsigned int>(Gecode::Int::Limits::max)),
+            rand(static_cast<unsigned int>(Gecode::Int::Limits::max)),
             static_cast<FloatNum>(Gecode::Int::Limits::max)
           ),
           r.sub_down(d.max(),d.min())
@@ -127,10 +128,10 @@ namespace Test { namespace Float {
   }
 
   inline
-  RandomAssignment::RandomAssignment(int n, const Gecode::FloatVal& d, int a0)
+  RandomAssignment::RandomAssignment(int n, const Gecode::FloatVal& d, int a0, Gecode::Support::RandomGenerator& rand)
     : Assignment(n,d), vals(new Gecode::FloatVal[n]), a(a0) {
     for (int i=n; i--; )
-      vals[i] = randval();
+      vals[i] = randval(rand);
   }
 
   inline bool
@@ -271,7 +272,7 @@ namespace Test { namespace Float {
 
   inline bool
   Test::flip(void) {
-    return Base::rand(2U) == 0U;
+    return _rand(2U) == 0U;
   }
 
   inline MaybeType

--- a/test/float.hpp
+++ b/test/float.hpp
@@ -61,7 +61,7 @@ namespace Test { namespace Float {
       dsv[i] = FloatVal(d.min(),nextafter(d.min(),d.max()));
   }
   inline bool
-  CpltAssignment::operator()(void) const {
+  CpltAssignment::has_more() const {
     return dsv[0].min() <= d.max();
   }
   inline Gecode::FloatVal
@@ -90,7 +90,7 @@ namespace Test { namespace Float {
     (*this).next();
   }
   inline bool
-  ExtAssignment::operator()(void) const {
+  ExtAssignment::has_more() const {
     return dsv[0].min() <= d.max();
   }
   inline Gecode::FloatVal
@@ -134,7 +134,7 @@ namespace Test { namespace Float {
   }
 
   inline bool
-  RandomAssignment::operator()(void) const {
+  RandomAssignment::has_more() const {
     return a>0;
   }
   inline Gecode::FloatVal

--- a/test/int.cpp
+++ b/test/int.cpp
@@ -489,7 +489,7 @@ do {                                                            \
     DFS<TestSpace> e_s(search_s,search_o);
     delete search_s;
 
-    while (a()) {
+    while (a.has_more()) {
       bool sol = solution(a);
       if (opt.log) {
         olog << ind(1) << "Assignment: " << a
@@ -1142,7 +1142,7 @@ do {                                                            \
       olog << "FAILURE" << std::endl
            << ind(1) << "Test:       " << test << std::endl
            << ind(1) << "Problem:    " << problem << std::endl;
-    if (a() && opt.log)
+    if (a.has_more() && opt.log)
       olog << ind(1) << "Assignment: " << a << std::endl;
     delete ap;
 

--- a/test/int.cpp
+++ b/test/int.cpp
@@ -444,19 +444,23 @@ namespace Test { namespace Int {
 
   /// Check the test result and handle failed test
 #define CHECK_TEST(T,M)                                         \
+do {                                                            \
 if (opt.log)                                                    \
   olog << ind(3) << "Check: " << (M) << std::endl;              \
 if (!(T)) {                                                     \
   problem = (M); delete s; goto failed;                         \
-}
+}                                                               \
+} while (false)
 
   /// Start new test
 #define START_TEST(T)                                           \
+do {                                                            \
   if (opt.log) {                                                \
      olog.str("");                                              \
      olog << ind(2) << "Testing: " << (T) << std::endl;         \
   }                                                             \
-  test = (T);
+  test = (T);                                                   \
+} while (false)
 
   bool
   Test::ignore(const Assignment&) const {

--- a/test/int.cpp
+++ b/test/int.cpp
@@ -45,7 +45,7 @@ namespace Test { namespace Int {
    *
    */
   void
-  CpltAssignment::operator++(void) {
+  CpltAssignment::next(void) {
     int i = n-1;
     while (true) {
       ++dsv[i];
@@ -59,15 +59,14 @@ namespace Test { namespace Int {
    * Random assignments
    *
    */
-  void
-  RandomAssignment::operator++(void) {
-    for (int i = n; i--; )
-      vals[i]=randval();
-    a--;
+  void RandomAssignment::next() {
+    for (int i = this->n; i--; )
+      this->vals[i]= this->randval();
+    this->a--;
   }
 
   void
-  RandomMixAssignment::operator++(void) {
+  RandomMixAssignment::next(void) {
     for (int i=n-_n1; i--; )
       vals[i] = randval(d);
     for (int i=_n1; i--; )
@@ -1077,7 +1076,7 @@ do {                                                            \
         }
       }
 
-      ++a;
+      a.next();
     }
 
     if (testsearch) {

--- a/test/int.hh
+++ b/test/int.hh
@@ -64,7 +64,7 @@ namespace Test {
       /// Initialize assignments for \a n0 variables and values \a d0
       Assignment(int n0, const Gecode::IntSet& d0);
       /// Test whether all assignments have been iterated
-      virtual bool operator()(void) const = 0;
+      virtual bool has_more(void) const = 0;
       /// Move to next assignment
       virtual void next(void) = 0;
       /// Return value for variable \a i
@@ -83,7 +83,7 @@ namespace Test {
       /// Initialize assignments for \a n0 variables and values \a d0
       CpltAssignment(int n, const Gecode::IntSet& d);
       /// Test whether all assignments have been iterated
-      virtual bool operator()(void) const;
+      virtual bool has_more(void) const;
       /// Move to next assignment
       virtual void next(void);
       /// Return value for variable \a i
@@ -103,7 +103,7 @@ namespace Test {
       /// Initialize for \a a assignments for \a n0 variables and values \a d0
       RandomAssignment(int n, const Gecode::IntSet& d, int a);
       /// Test whether all assignments have been iterated
-      virtual bool operator()(void) const;
+      virtual bool has_more(void) const;
       /// Move to next assignment
       virtual void next(void);
       /// Return value for variable \a i
@@ -126,7 +126,7 @@ namespace Test {
       RandomMixAssignment(int n0, const Gecode::IntSet& d0,
                           int n1, const Gecode::IntSet& d1, int a0);
       /// Test whether all assignments have been iterated
-      virtual bool operator()(void) const;
+      virtual bool has_more(void) const;
       /// Move to next assignment
       virtual void next(void);
       /// Return value for variable \a i

--- a/test/int.hh
+++ b/test/int.hh
@@ -66,7 +66,7 @@ namespace Test {
       /// Test whether all assignments have been iterated
       virtual bool operator()(void) const = 0;
       /// Move to next assignment
-      virtual void operator++(void) = 0;
+      virtual void next(void) = 0;
       /// Return value for variable \a i
       virtual int operator[](int i) const = 0;
       /// Return number of variables
@@ -85,7 +85,7 @@ namespace Test {
       /// Test whether all assignments have been iterated
       virtual bool operator()(void) const;
       /// Move to next assignment
-      virtual void operator++(void);
+      virtual void next(void);
       /// Return value for variable \a i
       virtual int operator[](int i) const;
       /// Destructor
@@ -105,7 +105,7 @@ namespace Test {
       /// Test whether all assignments have been iterated
       virtual bool operator()(void) const;
       /// Move to next assignment
-      virtual void operator++(void);
+      virtual void next(void);
       /// Return value for variable \a i
       virtual int operator[](int i) const;
       /// Destructor
@@ -128,7 +128,7 @@ namespace Test {
       /// Test whether all assignments have been iterated
       virtual bool operator()(void) const;
       /// Move to next assignment
-      virtual void operator++(void);
+      virtual void next(void);
       /// Return value for variable \a i
       virtual int operator[](int i) const;
       /// Destructor

--- a/test/int.hh
+++ b/test/int.hh
@@ -66,7 +66,7 @@ namespace Test {
       /// Test whether all assignments have been iterated
       virtual bool has_more(void) const = 0;
       /// Move to next assignment
-      virtual void next(void) = 0;
+      virtual void next(Gecode::Support::RandomGenerator& rand) = 0;
       /// Return value for variable \a i
       virtual int operator[](int i) const = 0;
       /// Return number of variables
@@ -85,7 +85,7 @@ namespace Test {
       /// Test whether all assignments have been iterated
       virtual bool has_more(void) const;
       /// Move to next assignment
-      virtual void next(void);
+      virtual void next(Gecode::Support::RandomGenerator& rand);
       /// Return value for variable \a i
       virtual int operator[](int i) const;
       /// Destructor
@@ -98,14 +98,14 @@ namespace Test {
       int* vals; ///< The current values for the variables
       int  a;    ///< How many assigments still to be generated
       /// Generate new value according to domain
-      int randval(void);
+      int randval(Gecode::Support::RandomGenerator& rand);
     public:
       /// Initialize for \a a assignments for \a n0 variables and values \a d0
-      RandomAssignment(int n, const Gecode::IntSet& d, int a);
+      RandomAssignment(int n, const Gecode::IntSet& d, int a0, Gecode::Support::RandomGenerator& rand);
       /// Test whether all assignments have been iterated
       virtual bool has_more(void) const;
       /// Move to next assignment
-      virtual void next(void);
+      virtual void next(Gecode::Support::RandomGenerator& rand);
       /// Return value for variable \a i
       virtual int operator[](int i) const;
       /// Destructor
@@ -120,15 +120,15 @@ namespace Test {
       int _n1;   ///< How many variables in the second set
       Gecode::IntSet _d1; ///< Domain for second set of variables
       /// Generate new value according to domain \a d
-      int randval(const Gecode::IntSet& d);
+      int randval(const Gecode::IntSet& d, Gecode::Support::RandomGenerator& rand);
     public:
       /// Initialize for \a a assignments for \a n0 variables and values \a d0
-      RandomMixAssignment(int n0, const Gecode::IntSet& d0,
-                          int n1, const Gecode::IntSet& d1, int a0);
+      RandomMixAssignment(int n0, const Gecode::IntSet& d0, int n1, const Gecode::IntSet& d1, int a0,
+                          Gecode::Support::RandomGenerator& rand);
       /// Test whether all assignments have been iterated
       virtual bool has_more(void) const;
       /// Move to next assignment
-      virtual void next(void);
+      virtual void next(Gecode::Support::RandomGenerator& rand);
       /// Return value for variable \a i
       virtual int operator[](int i) const;
       /// Destructor
@@ -185,33 +185,33 @@ namespace Test {
       /// Compute a fixpoint and check for failure
       bool failed(void);
       /// Randomly select an unassigned variable
-      int rndvar(void);
+      int rndvar(Gecode::Support::RandomGenerator& rand);
       /// Randomly select a pruning rel for variable \a i
-      void rndrel(const Assignment& a, int i, Gecode::IntRelType& irt, int& v);
+      void rndrel(const Assignment& a, int i, Gecode::IntRelType& irt, int& v, Gecode::Support::RandomGenerator& rand);
       /// Perform integer tell operation on \a x[i]
       void rel(int i, Gecode::IntRelType irt, int n);
       /// Perform Boolean tell on \a b
       void rel(bool sol);
       /// Assign all (or all but one, if \a skip is true) variables to values in \a a
-      void assign(const Assignment& a, bool skip=false);
+      void assign(const Assignment& a, bool skip, Gecode::Support::RandomGenerator& rand);
       /// Assing a random variable to a random bound
-      void bound(void);
+      void bound(Gecode::Support::RandomGenerator& rand);
       /** \brief Prune some random values from variable \a i
        *
        * If \a bounds_only is true, then the pruning is only done on the
        * bounds of the variable.
        */
-      void prune(int i, bool bounds_only);
+      void prune(int i, bool bounds_only, Gecode::Support::RandomGenerator& rand);
       /// Prune some random values for some random variable
-      void prune(void);
+      void prune(Gecode::Support::RandomGenerator& rand);
       /// Prune values but not those in assignment \a a
-      bool prune(const Assignment& a, bool testfix);
+      bool prune(const Assignment& a, bool testfix, Gecode::Support::RandomGenerator& rand);
       /// Disable propagators in space and compute fixpoint (make all idle)
       void disable(void);
       /// Enable propagators in space
       void enable(void);
       /// Prune values also in a space \a c with disabled propagators, but not those in assignment \a a
-      bool disabled(const Assignment& a, TestSpace& c, bool testfix);
+      bool disabled(const Assignment& a, TestSpace& c, bool testfix, Gecode::Support::RandomGenerator& rand);
       /// Return the number of propagators
       unsigned int propagators(void);
     };

--- a/test/int.hpp
+++ b/test/int.hpp
@@ -58,7 +58,7 @@ namespace Test { namespace Int {
       dsv[i].init(d);
   }
   inline bool
-  CpltAssignment::operator()(void) const {
+  CpltAssignment::has_more(void) const {
     return dsv[0]();
   }
   inline int
@@ -92,7 +92,7 @@ namespace Test { namespace Int {
   }
 
   inline bool
-  RandomAssignment::operator()(void) const {
+  RandomAssignment::has_more(void) const {
     return a>0;
   }
   inline int
@@ -130,7 +130,7 @@ namespace Test { namespace Int {
   }
 
   inline bool
-  RandomMixAssignment::operator()(void) const {
+  RandomMixAssignment::has_more(void) const {
     return a>0;
   }
 

--- a/test/int.hpp
+++ b/test/int.hpp
@@ -73,8 +73,8 @@ namespace Test { namespace Int {
 
 
   forceinline int
-  RandomAssignment::randval(void) {
-    unsigned int skip = Base::rand(d.size());
+  RandomAssignment::randval(Gecode::Support::RandomGenerator& rand) {
+    unsigned int skip = rand(d.size());
     for (Gecode::IntSetRanges it(d); true; ++it) {
       if (it.width() > skip)
         return it.min() + static_cast<int>(skip);
@@ -85,10 +85,10 @@ namespace Test { namespace Int {
   }
 
   inline
-  RandomAssignment::RandomAssignment(int n, const Gecode::IntSet& d, int a0)
+  RandomAssignment::RandomAssignment(int n, const Gecode::IntSet& d, int a0, Gecode::Support::RandomGenerator& rand)
     : Assignment(n,d), vals(new int[static_cast<size_t>(n)]), a(a0) {
     for (int i=n; i--; )
-      vals[i] = randval();
+      vals[i] = randval(rand);
   }
 
   inline bool
@@ -106,8 +106,8 @@ namespace Test { namespace Int {
   }
 
   forceinline int
-  RandomMixAssignment::randval(const Gecode::IntSet& d) {
-    unsigned int skip = Base::rand(d.size());
+  RandomMixAssignment::randval(const Gecode::IntSet& d, Gecode::Support::RandomGenerator& rand) {
+    unsigned int skip = rand(d.size());
     for (Gecode::IntSetRanges it(d); true; ++it) {
       if (it.width() > skip)
         return it.min() + static_cast<int>(skip);
@@ -118,15 +118,14 @@ namespace Test { namespace Int {
   }
 
   inline
-  RandomMixAssignment::RandomMixAssignment(int n0, const Gecode::IntSet& d0,
-                                           int n1, const Gecode::IntSet& d1,
-                                           int a0)
+  RandomMixAssignment::RandomMixAssignment(int n0, const Gecode::IntSet& d0, int n1, const Gecode::IntSet& d1, int a0,
+                                           Gecode::Support::RandomGenerator& rand)
     : Assignment(n0+n1,d0),vals(new int[static_cast<size_t>(n0+n1)]),
       a(a0),_n1(n1),_d1(d1) {
     for (int i=n0; i--; )
-      vals[i] = randval(d);
+      vals[i] = randval(d, rand);
     for (int i=n1; i--; )
-      vals[n0+i] = randval(_d1);
+      vals[n0+i] = randval(_d1, rand);
   }
 
   inline bool

--- a/test/int/bin-packing.cpp
+++ b/test/int/bin-packing.cpp
@@ -79,7 +79,7 @@ namespace Test { namespace Int {
         return dsv[0]();
       }
       /// Move to next assignment
-      virtual void operator++(void) {
+      virtual void next(void) {
         // Try to generate next bin assignment
         {
           int i = n_items-1;

--- a/test/int/bin-packing.cpp
+++ b/test/int/bin-packing.cpp
@@ -75,7 +75,7 @@ namespace Test { namespace Int {
           dsv[n_bins+i].init(d_bin);
       }
       /// Test whether all assignments have been iterated
-      virtual bool operator()(void) const {
+      virtual bool has_more(void) const {
         return dsv[0]();
       }
       /// Move to next assignment

--- a/test/int/bin-packing.cpp
+++ b/test/int/bin-packing.cpp
@@ -79,7 +79,7 @@ namespace Test { namespace Int {
         return dsv[0]();
       }
       /// Move to next assignment
-      virtual void next(void) {
+      virtual void next(Gecode::Support::RandomGenerator&) {
         // Try to generate next bin assignment
         {
           int i = n_items-1;
@@ -283,7 +283,7 @@ namespace Test { namespace Int {
           s[i]=1;
         // Create some random conflicts
         for (int i=clique.size()-1; i--; )
-          s[rand(n_items)*2+0]=2;
+          s[_rand(n_items)*2+0]=2;
         // Create conflicts corresponding to the clique
         for (int i=clique.size(); i--; )
           s[clique[i]*2+1]=2;

--- a/test/int/bool.cpp
+++ b/test/int/bool.cpp
@@ -455,7 +455,7 @@ namespace Test { namespace Int {
        /// Post constraint
        virtual void post(Gecode::Space& home, Gecode::IntVarArray& x) {
          using namespace Gecode;
-         if (Base::rand(2) != 0)
+         if (_rand(2) != 0)
            ite(home,channel(home,x[0]),x[1],x[2],x[3]);
          else
            rel(home, ite(channel(home,x[0]),x[1],x[2]) == x[3]);

--- a/test/int/cumulative.cpp
+++ b/test/int/cumulative.cpp
@@ -81,7 +81,7 @@ namespace Test { namespace Int {
       }
       /// Create and register initial assignment
       virtual Assignment* assignment(void) const {
-        return new RandomAssignment(arity,dom,500);
+        return new RandomAssignment(arity, dom, 500, _rand);
       }
       /// Test whether \a x is solution
       virtual bool solution(const Assignment& x) const {
@@ -185,7 +185,7 @@ namespace Test { namespace Int {
       }
       /// Create and register initial assignment
       virtual Assignment* assignment(void) const {
-        return new RandomAssignment(arity,dom,500);
+        return new RandomAssignment(arity, dom, 500, _rand);
       }
       /// Test whether \a x is solution
       virtual bool solution(const Assignment& x) const {
@@ -292,9 +292,9 @@ namespace Test { namespace Int {
       }
       /// Create and register initial assignment
       virtual Assignment* assignment(void) const {
-        return new RandomMixAssignment((c >= 0) ? arity/2 : arity/2+1,
-                                       dom,arity/2,
-                                       Gecode::IntSet(_minP,_maxP),500);
+        return new RandomMixAssignment((c >= 0) ? arity / 2 : arity / 2 + 1,
+                                       dom, arity / 2,
+                                       Gecode::IntSet(_minP, _maxP), 500, _rand);
       }
       /// Test whether \a x is solution
       virtual bool solution(const Assignment& x) const {
@@ -406,9 +406,9 @@ namespace Test { namespace Int {
       }
       /// Create and register initial assignment
       virtual Assignment* assignment(void) const {
-        return new RandomMixAssignment((c >= 0) ? 2*(arity/3) : 2*(arity/3)+1,
-                                       dom,arity/3,
-                                       Gecode::IntSet(_minP,_maxP),500);
+        return new RandomMixAssignment((c >= 0) ? 2 * (arity / 3) : 2 * (arity / 3) + 1,
+                                       dom, arity / 3,
+                                       Gecode::IntSet(_minP, _maxP), 500, _rand);
       }
       /// Test whether \a x is solution
       virtual bool solution(const Assignment& x) const {

--- a/test/int/cumulatives.cpp
+++ b/test/int/cumulatives.cpp
@@ -109,7 +109,7 @@ namespace Test { namespace Int {
          return nxt != nullptr;
        }
        /// Move to next assignment
-       virtual void next(void) {
+       virtual void next(Gecode::Support::RandomGenerator&) {
          delete cur;
          cur = nxt;
          if (cur != nullptr) nxt = e->next();

--- a/test/int/cumulatives.cpp
+++ b/test/int/cumulatives.cpp
@@ -105,7 +105,7 @@ namespace Test { namespace Int {
            nxt = e->next();
        }
        /// %Test whether all assignments have been iterated
-       virtual bool operator()(void) const {
+       virtual bool has_more(void) const {
          return nxt != nullptr;
        }
        /// Move to next assignment

--- a/test/int/cumulatives.cpp
+++ b/test/int/cumulatives.cpp
@@ -109,13 +109,13 @@ namespace Test { namespace Int {
          return nxt != nullptr;
        }
        /// Move to next assignment
-       virtual void operator++(void) {
+       virtual void next(void) {
          delete cur;
          cur = nxt;
          if (cur != nullptr) nxt = e->next();
        }
        /// Return value for variable \a i
-       virtual int  operator[](int i) const {
+       virtual int operator[](int i) const {
          assert((i>=0) && (i<n) && (cur != nullptr));
          return cur->x[i].val();
        }

--- a/test/int/distinct.cpp
+++ b/test/int/distinct.cpp
@@ -173,7 +173,7 @@ namespace Test { namespace Int {
        }
        /// Create and register initial assignment
        virtual Assignment* assignment(void) const {
-         return new RandomAssignment(arity,dom,100);
+         return new RandomAssignment(arity, dom, 100, _rand);
        }
        /// Check whether \a x is solution
        virtual bool solution(const Assignment& x) const {

--- a/test/int/dom.cpp
+++ b/test/int/dom.cpp
@@ -70,7 +70,7 @@ namespace Test { namespace Int {
        virtual void post(Gecode::Space& home, Gecode::IntVarArray& x,
                          Gecode::Reify r) {
          assert(x.size() == 1);
-         if (Base::rand(2) != 0) {
+         if (_rand(2) != 0) {
            Gecode::dom(home, x[0], -2, r);
          } else {
            switch (r.mode()) {
@@ -112,7 +112,7 @@ namespace Test { namespace Int {
        virtual void post(Gecode::Space& home, Gecode::IntVarArray& x,
                          Gecode::Reify r) {
          assert(x.size() == 1);
-         if (Base::rand(2) != 0) {
+         if (_rand(2) != 0) {
            Gecode::dom(home, x[0], -2, 2, r);
          } else {
            switch (r.mode()) {
@@ -182,7 +182,7 @@ namespace Test { namespace Int {
        virtual void post(Gecode::Space& home, Gecode::IntVarArray& x,
                          Gecode::Reify r) {
          assert(x.size() == 1);
-         if (Base::rand(2) != 0) {
+         if (_rand(2) != 0) {
            Gecode::dom(home, x[0], d, r);
          } else {
            switch (r.mode()) {

--- a/test/int/element.cpp
+++ b/test/int/element.cpp
@@ -261,7 +261,7 @@ namespace Test { namespace Int {
          for (int i=0; i<x.size()-1; i++)
            c[i]=channel(home,x[1+i]);
          if (r == 1) {
-           switch (Base::rand(3)) {
+           switch (_rand(3)) {
            case 0:
              element(home, c, x[0], 1);
              break;

--- a/test/int/extensional.cpp
+++ b/test/int/extensional.cpp
@@ -496,7 +496,7 @@ namespace Test { namespace Int {
        /// Create and register initial assignment
        virtual Assignment* assignment(void) const {
          using namespace Gecode;
-         return new RandomAssignment(arity,dom,1000);
+         return new RandomAssignment(arity, dom, 1000, _rand);
        }
      };
 
@@ -516,12 +516,12 @@ namespace Test { namespace Int {
 
          CpltAssignment ass(5, IntSet(1, 5));
          while (ass.has_more()) {
-           if (Base::rand(100) <= prob*100) {
+           if (_rand(100) <= prob*100) {
              IntArgs tuple(5);
              for (int i = 5; i--; ) tuple[i] = ass[i];
              t.add(tuple);
            }
-           ass.next();
+           ass.next(_rand);
          }
          t.finalize();
        }
@@ -567,12 +567,12 @@ namespace Test { namespace Int {
 
          CpltAssignment ass(5, IntSet(0, 1));
          while (ass.has_more()) {
-           if (Base::rand(100) <= prob*100) {
+           if (_rand(100) <= prob*100) {
              IntArgs tuple(5);
              for (int i = 5; i--; ) tuple[i] = ass[i];
              t.add(tuple);
            }
-           ass.next();
+           ass.next(_rand);
          }
          t.finalize();
        }
@@ -613,7 +613,7 @@ namespace Test { namespace Int {
      class TupleSetTestSize {
      public:
        /// Perform creation and registration
-       TupleSetTestSize(int size, bool pos) {
+       TupleSetTestSize(int size, bool pos, Gecode::Support::RandomGenerator& rand) {
          using namespace Gecode;
          /// Find the arity needed for creating sufficient number of tuples
          int arity = 2;
@@ -630,7 +630,7 @@ namespace Test { namespace Int {
            IntArgs tuple(arity);
            for (int j = arity; j--; ) tuple[j] = ass[j];
            ts.add(tuple);
-           ass.next();
+           ass.next(rand);
          }
          ts.finalize();
          assert(ts.tuples() == size);
@@ -640,17 +640,17 @@ namespace Test { namespace Int {
        }
      };
 
-     Gecode::TupleSet randomTupleSet(int n, int min, int max, double prob) {
+     Gecode::TupleSet randomTupleSet(int n, int min, int max, double prob, Gecode::Support::RandomGenerator& rand) {
        using namespace Gecode;
        TupleSet t(n);
        CpltAssignment ass(n, IntSet(min, max));
        while (ass.has_more()) {
-         if (Base::rand(100) <= prob*100) {
+         if (rand(100) <= prob*100) {
            IntArgs tuple(n);
            for (int i = n; i--; ) tuple[i] = ass[i];
            t.add(tuple);
          }
-         ass.next();
+         ass.next(rand);
        }
        t.finalize();
        return t;
@@ -661,6 +661,13 @@ namespace Test { namespace Int {
      public:
        /// Perform creation and registration
        Create(void) {
+         // This code is executed on load, and thus a random number generator source from the supplied
+         // seed is not available.
+         // In order to get interesting data her, but still have deterministic and repeatable execution, a fixed seed
+         // is used for a local random number generator.
+         // TODO: Make this code later on test run, and use the supplied seed/random number generator.
+         Gecode::Support::RandomGenerator rand(42);
+
          using namespace Gecode;
          for (bool pos : { false, true }) {
            {
@@ -724,7 +731,7 @@ namespace Test { namespace Int {
              for (int i = 0; i < 10000; i++) {
                IntArgs tuple(7);
                for (int j = 0; j < 7; j++) {
-                 tuple[j] = Base::rand(j+1);
+                 tuple[j] = rand(j+1);
                }
                ts.add(tuple);
              }
@@ -733,15 +740,15 @@ namespace Test { namespace Int {
            }
            {
              for (int i = 0; i <= 64*6; i+=32)
-               (void) new TupleSetTestSize(i,pos);
+               (void) new TupleSetTestSize(i, pos, rand);
            }
            {
              (void) new RandomTupleSetTest("Rand(10,-1,2)", pos,
                                            IntSet(-1,2),
-                                           randomTupleSet(10,-1,2,0.05));
+                                           randomTupleSet(10, -1, 2, 0.05, rand));
              (void) new RandomTupleSetTest("Rand(5,-10,10)", pos,
                                            IntSet(-10,10),
-                                           randomTupleSet(5,-10,10,0.05));
+                                           randomTupleSet(5, -10, 10, 0.05, rand));
            }
            {
              TupleSet t(5);
@@ -751,7 +758,7 @@ namespace Test { namespace Int {
                tuple[4] = 1;
                for (int i = 4; i--; ) tuple[i] = ass[i];
                t.add(tuple);
-               ass.next();
+               ass.next(rand);
              }
              t.add({2,2,4,3,4});
              t.finalize();
@@ -762,7 +769,7 @@ namespace Test { namespace Int {
              CpltAssignment ass(4, IntSet(1, 6));
              while (ass.has_more()) {
                t.add({ass[0],0,ass[1],ass[2]});
-               ass.next();
+               ass.next(rand);
              }
              t.add({2,-1,3,4});
              t.finalize();
@@ -772,13 +779,13 @@ namespace Test { namespace Int {
              TupleSet t(10);
              CpltAssignment ass(9, IntSet(1, 4));
              while (ass.has_more()) {
-               if (Base::rand(100) <= 0.25*100) {
+               if (rand(100) <= 0.25*100) {
                  IntArgs tuple(10);
                  tuple[0] = 2;
                  for (int i = 9; i--; ) tuple[i+1] = ass[i];
                  t.add(tuple);
                }
-               ass.next();
+               ass.next(rand);
              }
              t.add({1,1,1,1,1,1,1,1,1,1});
              t.add({1,2,3,4,4,2,1,2,3,3});

--- a/test/int/extensional.cpp
+++ b/test/int/extensional.cpp
@@ -521,7 +521,7 @@ namespace Test { namespace Int {
              for (int i = 5; i--; ) tuple[i] = ass[i];
              t.add(tuple);
            }
-           ++ass;
+           ass.next();
          }
          t.finalize();
        }
@@ -550,7 +550,7 @@ namespace Test { namespace Int {
          extensional(home, x, t, pos, r, ipl);
        }
      };
-     
+
      /// %Test with bool tuple set
      class TupleSetBool : public Test {
      protected:
@@ -572,7 +572,7 @@ namespace Test { namespace Int {
              for (int i = 5; i--; ) tuple[i] = ass[i];
              t.add(tuple);
            }
-           ++ass;
+           ass.next();
          }
          t.finalize();
        }
@@ -630,7 +630,7 @@ namespace Test { namespace Int {
            IntArgs tuple(arity);
            for (int j = arity; j--; ) tuple[j] = ass[j];
            ts.add(tuple);
-           ++ass;
+           ass.next();
          }
          ts.finalize();
          assert(ts.tuples() == size);
@@ -650,12 +650,12 @@ namespace Test { namespace Int {
            for (int i = n; i--; ) tuple[i] = ass[i];
            t.add(tuple);
          }
-         ++ass;
+         ass.next();
        }
        t.finalize();
        return t;
      }
-     
+
      /// Help class to create and register tests
      class Create {
      public:
@@ -751,7 +751,7 @@ namespace Test { namespace Int {
                tuple[4] = 1;
                for (int i = 4; i--; ) tuple[i] = ass[i];
                t.add(tuple);
-               ++ass;
+               ass.next();
              }
              t.add({2,2,4,3,4});
              t.finalize();
@@ -762,7 +762,7 @@ namespace Test { namespace Int {
              CpltAssignment ass(4, IntSet(1, 6));
              while (ass()) {
                t.add({ass[0],0,ass[1],ass[2]});
-               ++ass;
+               ass.next();
              }
              t.add({2,-1,3,4});
              t.finalize();
@@ -778,7 +778,7 @@ namespace Test { namespace Int {
                  for (int i = 9; i--; ) tuple[i+1] = ass[i];
                  t.add(tuple);
                }
-               ++ass;
+               ass.next();
              }
              t.add({1,1,1,1,1,1,1,1,1,1});
              t.add({1,2,3,4,4,2,1,2,3,3});
@@ -791,7 +791,7 @@ namespace Test { namespace Int {
          }
        }
      };
-     
+
      Create c;
 
      RegSimpleA ra;

--- a/test/int/extensional.cpp
+++ b/test/int/extensional.cpp
@@ -515,7 +515,7 @@ namespace Test { namespace Int {
          using namespace Gecode;
 
          CpltAssignment ass(5, IntSet(1, 5));
-         while (ass()) {
+         while (ass.has_more()) {
            if (Base::rand(100) <= prob*100) {
              IntArgs tuple(5);
              for (int i = 5; i--; ) tuple[i] = ass[i];
@@ -566,7 +566,7 @@ namespace Test { namespace Int {
          using namespace Gecode;
 
          CpltAssignment ass(5, IntSet(0, 1));
-         while (ass()) {
+         while (ass.has_more()) {
            if (Base::rand(100) <= prob*100) {
              IntArgs tuple(5);
              for (int i = 5; i--; ) tuple[i] = ass[i];
@@ -626,7 +626,7 @@ namespace Test { namespace Int {
          TupleSet ts(arity);
          CpltAssignment ass(arity, IntSet(0, 4));
          for (int i = size; i--; ) {
-           assert(ass());
+           assert(ass.has_more());
            IntArgs tuple(arity);
            for (int j = arity; j--; ) tuple[j] = ass[j];
            ts.add(tuple);
@@ -644,7 +644,7 @@ namespace Test { namespace Int {
        using namespace Gecode;
        TupleSet t(n);
        CpltAssignment ass(n, IntSet(min, max));
-       while (ass()) {
+       while (ass.has_more()) {
          if (Base::rand(100) <= prob*100) {
            IntArgs tuple(n);
            for (int i = n; i--; ) tuple[i] = ass[i];
@@ -746,7 +746,7 @@ namespace Test { namespace Int {
            {
              TupleSet t(5);
              CpltAssignment ass(4, IntSet(1, 4));
-             while (ass()) {
+             while (ass.has_more()) {
                IntArgs tuple(5);
                tuple[4] = 1;
                for (int i = 4; i--; ) tuple[i] = ass[i];
@@ -760,7 +760,7 @@ namespace Test { namespace Int {
            {
              TupleSet t(4);
              CpltAssignment ass(4, IntSet(1, 6));
-             while (ass()) {
+             while (ass.has_more()) {
                t.add({ass[0],0,ass[1],ass[2]});
                ass.next();
              }
@@ -771,7 +771,7 @@ namespace Test { namespace Int {
            {
              TupleSet t(10);
              CpltAssignment ass(9, IntSet(1, 4));
-             while (ass()) {
+             while (ass.has_more()) {
                if (Base::rand(100) <= 0.25*100) {
                  IntArgs tuple(10);
                  tuple[0] = 2;

--- a/test/int/gcc.cpp
+++ b/test/int/gcc.cpp
@@ -268,7 +268,7 @@ namespace Test { namespace Int {
        /// Create and register initial assignment
        virtual Assignment* assignment(void) const {
          if (arity > randomArity)
-           return new RandomAssignment(arity,dom,4000);
+           return new RandomAssignment(arity, dom, 4000, _rand);
          else
            return new CpltAssignment(arity,dom);
        }

--- a/test/int/nvalues.cpp
+++ b/test/int/nvalues.cpp
@@ -64,7 +64,7 @@ namespace Test { namespace Int {
        /// Create and register initial assignment
        virtual Assignment* assignment(void) const {
          if (arity > 5)
-           return new RandomAssignment(arity,dom,500);
+           return new RandomAssignment(arity, dom, 500, _rand);
          else
            return new CpltAssignment(arity,dom);
        }

--- a/test/int/unary.cpp
+++ b/test/int/unary.cpp
@@ -70,7 +70,7 @@ namespace Test { namespace Int { namespace Unary {
     }
     /// Create and register initial assignment
     virtual Assignment* assignment(void) const {
-      return new RandomAssignment(arity,dom,500);
+      return new RandomAssignment(arity, dom, 500, _rand);
     }
     /// %Test whether \a x is solution
     virtual bool solution(const Assignment& x) const {
@@ -110,7 +110,7 @@ namespace Test { namespace Int { namespace Unary {
     }
     /// Create and register initial assignment
     virtual Assignment* assignment(void) const {
-      return new RandomAssignment(arity,dom,500);
+      return new RandomAssignment(arity, dom, 500, _rand);
     }
     /// %Test whether \a x is solution
     virtual bool solution(const Assignment& x) const {
@@ -157,8 +157,8 @@ namespace Test { namespace Int { namespace Unary {
     }
     /// Create and register initial assignment
     virtual Assignment* assignment(void) const {
-      return new RandomMixAssignment(arity/2,dom,arity/2,
-                                     Gecode::IntSet(_minP,_maxP),500);
+      return new RandomMixAssignment(arity / 2, dom, arity / 2,
+                                     Gecode::IntSet(_minP, _maxP), 500, _rand);
     }
     /// %Test whether \a x is solution
     virtual bool solution(const Assignment& x) const {
@@ -217,8 +217,8 @@ namespace Test { namespace Int { namespace Unary {
     }
     /// Create and register initial assignment
     virtual Assignment* assignment(void) const {
-      return new RandomMixAssignment(2*(arity/3),dom,arity/3,
-                                     Gecode::IntSet(_minP,_maxP),500);
+      return new RandomMixAssignment(2 * (arity / 3), dom, arity / 3,
+                                     Gecode::IntSet(_minP, _maxP), 500, _rand);
     }
     /// %Test whether \a x is solution
     virtual bool solution(const Assignment& x) const {

--- a/test/set.cpp
+++ b/test/set.cpp
@@ -73,7 +73,7 @@ namespace Test { namespace Set {
   }
 
   void
-  SetAssignment::operator++(void) {
+  SetAssignment::next(void) {
     int i = n-1;
     while (true) {
       ++dsv[i];
@@ -86,7 +86,7 @@ namespace Test { namespace Set {
           done = true;
           return;
         }
-        ++ir;
+        ir.next();
         if (ir()) {
           i = n-1;
           for (int j=n; j--; )
@@ -1173,7 +1173,7 @@ if (!(T)) {                                                     \
           delete s;
         }
       }
-      ++a;
+      a.next();
     }
     delete ap;
     return true;

--- a/test/set.cpp
+++ b/test/set.cpp
@@ -700,19 +700,23 @@ namespace Test { namespace Set {
 
   /// Check the test result and handle failed test
 #define CHECK_TEST(T,M)                                         \
+do {                                                            \
 if (opt.log)                                                    \
   olog << ind(3) << "Check: " << (M) << std::endl;              \
 if (!(T)) {                                                     \
   problem = (M); delete s; goto failed;                         \
-}
+}                                                               \
+} while (false)
 
   /// Start new test
 #define START_TEST(T)                                           \
+  do {                                                          \
   if (opt.log) {                                                \
      olog.str("");                                              \
      olog << ind(2) << "Testing: " << (T) << std::endl;         \
   }                                                             \
-  test = (T);
+  test = (T);                                                   \
+  } while (false)
 
   bool
   SetTest::run(void) {

--- a/test/set.cpp
+++ b/test/set.cpp
@@ -87,7 +87,7 @@ namespace Test { namespace Set {
           return;
         }
         ir.next();
-        if (ir()) {
+        if (ir.has_more()) {
           i = n-1;
           for (int j=n; j--; )
             dsv[j].init(lub);

--- a/test/set.hh
+++ b/test/set.hh
@@ -159,7 +159,7 @@ namespace Test {
       /// Test whether all assignments have been iterated
       bool operator()(void) const { return !done; }
       /// Move to next assignment
-      void operator++(void);
+      void next(void);
       /// Return value for variable \a i
       int operator[](int i) const {
         assert((i>=0) && (i<n));

--- a/test/set.hh
+++ b/test/set.hh
@@ -159,7 +159,7 @@ namespace Test {
       /// Test whether all assignments have been iterated
       bool operator()(void) const { return !done; }
       /// Move to next assignment
-      void next(void);
+      void next(Gecode::Support::RandomGenerator& rand);
       /// Return value for variable \a i
       int operator[](int i) const {
         assert((i>=0) && (i<n));
@@ -237,7 +237,7 @@ namespace Test {
       /// Perform Boolean tell on \a b
       void rel(bool sol);
       /// Assign all variables to values in \a a
-      void assign(const SetAssignment& a);
+      void assign(const SetAssignment& a, Gecode::Support::RandomGenerator& rand);
       /// Test whether all variables are assigned
       bool assigned(void) const;
       /// Remove value \a v from the upper bound of \a x[i]
@@ -253,7 +253,7 @@ namespace Test {
       /// Perform fixpoint computation
       bool fixprob(void);
       /// Perform random pruning
-      bool prune(const SetAssignment& a);
+      bool prune(const SetAssignment& a, Gecode::Support::RandomGenerator& rand);
       /// Return the number of propagators
       unsigned int propagators(void);
       /// Disable propagators in space and compute fixpoint (make all idle)
@@ -261,7 +261,7 @@ namespace Test {
       /// Enable propagators in space
       void enable(void);
       /// Prune values also in a space \a c with disabled propagators, but not those in assignment \a a
-      bool disabled(const SetAssignment& a, SetTestSpace& c);
+      bool disabled(const SetAssignment& a, SetTestSpace& c, Gecode::Support::RandomGenerator& rand);
       /// Check whether propagation is the same as in \a c
       bool same(SetTestSpace& c);
     };

--- a/test/set/dom.cpp
+++ b/test/set/dom.cpp
@@ -167,7 +167,7 @@ namespace Test { namespace Set {
       /// Post reified constraint on \a x for \a b
       virtual void post(Space& home, SetVarArray& x, IntVarArray&, Reify r) {
         assert(x.size() == 1);
-        if (Base::rand(2) != 0) {
+        if (_rand(2) != 0) {
           Gecode::dom(home, x[0], srt, is, r);
         } else {
            switch (r.mode()) {
@@ -261,7 +261,7 @@ namespace Test { namespace Set {
       /// Post reified constraint on \a x for \a b
       virtual void post(Space& home, SetVarArray& x, IntVarArray&, Reify r) {
         assert(x.size() == 1);
-        if (Base::rand(2) != 0) {
+        if (_rand(2) != 0) {
           Gecode::dom(home, x[0], srt, -3, -1, r);
         } else {
            switch (r.mode()) {
@@ -357,7 +357,7 @@ namespace Test { namespace Set {
       /// Post reified constraint on \a x for \a b
       virtual void post(Space& home, SetVarArray& x, IntVarArray&, Reify r) {
         assert(x.size() == 1);
-        if (Base::rand(2) != 0) {
+        if (_rand(2) != 0) {
           Gecode::dom(home, x[0], srt, -3, r);
         } else {
            switch (r.mode()) {

--- a/test/set/int.cpp
+++ b/test/set/int.cpp
@@ -351,7 +351,7 @@ namespace Test { namespace Set {
       virtual void post(Space& home, SetVarArray& x, IntVarArray& y,
                         Reify r) {
         assert((x.size() == 1) && (y.size() == 1));
-        if ((r.mode() != Gecode::RM_EQV) || (Base::rand(2) != 0)) {
+        if ((r.mode() != Gecode::RM_EQV) || (_rand(2) != 0)) {
           if (!swapped)
             Gecode::rel(home, x[0], irt, y[0], r);
           else

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -112,6 +112,7 @@ namespace Test {
                   << "\t-threads (unsigned int) default: " << threads << std::endl
                   << "\t\tnumber of threads to use. If 0, as many threads as there are cores are used."
                   << "\t\tThreaded execution and logging can not be used at the same time."
+                  << std::endl
                   << "\t-seed (unsigned int or \"time\") default: "
                   << seed << std::endl
                   << "\t\tseed for random number generator (unsigned int),"
@@ -319,7 +320,7 @@ namespace Test {
     /// Choose a batch size based on the number of tests to divide
     static size_t choose_batch_size(size_t test_count, int thread_count) {
       const int batches_per_thread = 5;
-      std::array<size_t, 4> batch_sizes = {25, 10, 5, 2};
+      std::vector<size_t> batch_sizes = {25, 10, 5, 2};
       for (auto batch_size : batch_sizes) {
         if (test_count > batch_size * thread_count * batches_per_thread) {
           return batch_size;

--- a/test/test.hh
+++ b/test/test.hh
@@ -127,7 +127,9 @@ namespace Test {
     /// Run test
     virtual bool run(void) = 0;
     /// Throw a coin whether to compute a fixpoint
-    static bool fixpoint(void);
+    bool fixpoint(void);
+    /// Throw a coin whether to compute a fixpoint
+    static bool fixpoint(Gecode::Support::RandomGenerator& rand);
     /// Destructor
     virtual ~Base(void);
 
@@ -142,7 +144,7 @@ namespace Test {
     //@}
 
     /// Random number generator
-    static Gecode::Support::RandomGenerator rand;
+    mutable Gecode::Support::RandomGenerator _rand;
   };
   //@}
 

--- a/test/test.hh
+++ b/test/test.hh
@@ -72,6 +72,12 @@ namespace Test {
     ind(int i) : l(i) {}
   };
 
+  /// How to match
+  enum MatchType {
+    MT_ANY,  //< Positive match anywhere in string
+    MT_NOT,  //< Negative match
+    MT_FIRST //< Positive match at beginning
+  };
 
   /// Commandline options
   class Options {
@@ -90,11 +96,20 @@ namespace Test {
     bool stop;
     /// Whether to log the tests
     bool log;
+    /// Patterns to test against
+    std::vector<std::pair<MatchType, const char*> > testpat;
+    /// Name of first test to start with
+    const char* start_from;
+    /// Whether to list all tests
+    bool list;
 
     /// Initialize options with defaults
     Options(void);
     /// Parse commandline arguments
     void parse(int argc, char* argv[]);
+
+    /// True iff a test name should be executed according to the patterns. With no patterns, always true.
+    bool is_test_name_matching(const std::string& test_name);
   };
 
   /// The options

--- a/test/test.hh
+++ b/test/test.hh
@@ -82,6 +82,8 @@ namespace Test {
   /// Commandline options
   class Options {
   public:
+    /// Number of threads to use
+    unsigned int threads;
     /// The random seed to be used
     unsigned int seed;
     /// Number of iterations for each test

--- a/test/test.hpp
+++ b/test/test.hpp
@@ -64,6 +64,11 @@ namespace Test {
   }
   inline bool
   Base::fixpoint(void) {
+    return fixpoint(_rand);
+  }
+
+  inline bool
+  Base::fixpoint(Gecode::Support::RandomGenerator& rand) {
     return rand(opt.fixprob) == 0;
   }
 
@@ -72,7 +77,7 @@ namespace Test {
     std::stringstream s;
     if (b)
       s << "+";
-    else 
+    else
       s << "-";
     return s.str();
   }

--- a/test/test.hpp
+++ b/test/test.hpp
@@ -39,7 +39,7 @@ namespace Test {
    */
   inline
   Options::Options(void)
-    : seed(0), iter(defiter), fixprob(deffixprob), stop(true), log(false)
+    : seed(0), iter(defiter), fixprob(deffixprob), stop(true), log(false), testpat(), start_from(nullptr), list(false)
   {}
 
   /*


### PR DESCRIPTION
This branch adds the possibility to run tests in parallel.

For macOS, the system allocator is not good enough for running the test in parallel, and another allocator needs to be used, such as mimalloc.

In addition, a couple of speed issues in the kernel were uncovered for macOS, namely access to the region pool and the propagator identifier counter. These were fixed by making the region pool thread local and changing the guard of the propagator identifier from a mutex to using std::atomic instead.

As a consequence, there is no possibility to compile without C++11, and that configuration option has been removed.