### PR TITLE
use CMAKE_INSTALL_LIBDIR in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -495,9 +495,9 @@ add_test(test gecode-test
 # Install libraries and executables
 install(
   TARGETS ${GECODE_INSTALL_TARGETS}
-  RUNTIME DESTINATION bin
-  LIBRARY DESTINATION lib
-  ARCHIVE DESTINATION lib
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )
 install(
   FILES ${MZN_SCRIPT}
@@ -518,7 +518,7 @@ install(
 )
 install(
   FILES ${PROJECT_BINARY_DIR}/gecode/support/config.hpp
-  DESTINATION include/gecode/support/
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/gecode/support/
 )
 # Install MiniZinc library
 install(

--- a/LICENSE
+++ b/LICENSE
@@ -1,8 +1,6 @@
-		GECODE LICENSE AGREEMENT
-
-			(MIT License)
-
-This software and its documentation are copyrighted by the 
+		  GECODE LICENSE AGREEMENT
+			 
+This software and its documentation are copyrighted by the
 individual authors as listed in each file. The following
 terms apply to all files associated with the software unless
 explicitly disclaimed in individual files.


### PR DESCRIPTION
Sometimes libs need to be installed in `lib64` directory which is not supported right now as `lib` dir is hardcoded in `CMakeLists.txt`