### PR TITLE
Ready fzn-gecode as MiniZinc solver on `make install`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ cmake_install.cmake
 CMakeFiles
 bin
 gecode/support/config.hpp
+tools/flatzinc/gecode.msc
 tools/flatzinc/mzn-gecode.bat
 tools/flatzinc/fzn-gecode
 tools/flatzinc/mzn-gecode

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -469,6 +469,11 @@ else()
   )
   set(MZN_SCRIPT ${PROJECT_BINARY_DIR}/tools/flatzinc/mzn-gecode)
 endif()
+configure_file(
+  ${PROJECT_SOURCE_DIR}/tools/flatzinc/gecode.msc.in
+  ${PROJECT_BINARY_DIR}/tools/flatzinc/gecode.msc
+  @ONLY
+)
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
@@ -518,5 +523,9 @@ install(
 # Install MiniZinc library
 install(
   DIRECTORY gecode/flatzinc/mznlib
-  DESTINATION share/gecode
+  DESTINATION share/minizinc/gecode
+)
+install(
+  FILES ${PROJECT_BINARY_DIR}/tools/flatzinc/gecode.msc
+  DESTINATION share/minizinc/solvers
 )

--- a/Makefile.in
+++ b/Makefile.in
@@ -845,6 +845,7 @@ export FLATZINCSTATICLIB	= $(LIBPREFIX)@FLATZINC@$(STATICLIBSUFFIX)
 export FLATZINCLIB		= $(LIBPREFIX)@FLATZINC@$(LIBSUFFIX)
 export LINKFLATZINC		= $(LINKPREFIX)@FLATZINC@$(LINKSUFFIX)
 export FLATZINCMZNLIB		= gecode/flatzinc/mznlib
+export FLATZINCCONFIG		= tools/flatzinc/gecode.msc
 FLATZINCEXE	= tools/flatzinc/fzn-gecode$(EXESUFFIX)
 ifeq "@need_soname@" "yes"
 export FLATZINCSONAME = @WLSONAME@$(LIBPREFIX)@FLATZINC@$(SOSUFFIX)
@@ -1982,10 +1983,12 @@ doinstallheaders: $(ALLHDR:%=$(top_srcdir)/%) $(EXTRA_HEADERS) $(VARIMPHDR)
 	  for f in $$for_extraheaders; do \
 	    cp $$f $(DESTDIR)$(includedir)/$$f; done && \
 	for_mznlib="$(FLATZINCMZNLIB)" && \
+	  mkdir -p $(DESTDIR)$(datadir)/minizinc/solvers; \
+      cp $(FLATZINCCONFIG) $(DESTDIR)$(datadir)/minizinc/solvers/; \
+	  mkdir -p $(DESTDIR)$(datadir)/minizinc/gecode; \
 	  for f in $$for_mznlib; do \
-		mkdir -p $(DESTDIR)$(datadir)/gecode/mznlib; \
 		cp $(top_srcdir)/$$f/*.mzn \
-		  $(DESTDIR)$(datadir)/gecode/mznlib; done
+		  $(DESTDIR)$(datadir)/minizinc/gecode; done
 
 doinstalllib:
 	mkdir -p $(DESTDIR)$(sharedlibdir) && \

--- a/changelog.in
+++ b/changelog.in
@@ -76,6 +76,15 @@ Date: 2020-??-??
 Let's see.
 
 [ENTRY]
+Module: flatzinc
+What:   change
+Rank:   minor
+Thanks: Jip J. Dekker
+[DESCRIPTION]
+Automatically generate and install a MiniZinc solver configuration and
+install MiniZinc library into the share/minizinc/gecode standard location.
+
+[ENTRY]
 Module: int
 What:   new
 Rank:   minor

--- a/configure
+++ b/configure
@@ -632,6 +632,7 @@ DLL_ARCH
 ALLVIS
 GLDFLAGS
 DLLFLAGS
+GECODE_VERSION
 VERSION
 subdirs
 enable_search
@@ -13399,6 +13400,8 @@ subdirs="$subdirs "
 
 VERSION=${PACKAGE_VERSION}
 
+GECODE_VERSION=${PACKAGE_VERSION}
+
 DLLFLAGS=${DLLFLAGS}
 
 GLDFLAGS=${GLDFLAGS}
@@ -13456,6 +13459,8 @@ else
   ac_config_files="$ac_config_files tools/flatzinc/mzn-gecode:tools/flatzinc/mzn-gecode.in"
 
 fi
+ac_config_files="$ac_config_files tools/flatzinc/gecode.msc:tools/flatzinc/gecode.msc.in"
+
 ac_config_files="$ac_config_files doxygen.conf:doxygen/doxygen.conf.in"
 
 ac_config_files="$ac_config_files doxygen.hh:doxygen/doxygen.hh.in"
@@ -14153,6 +14158,7 @@ do
     "Makefile") CONFIG_FILES="$CONFIG_FILES Makefile" ;;
     "tools/flatzinc/mzn-gecode.bat") CONFIG_FILES="$CONFIG_FILES tools/flatzinc/mzn-gecode.bat:tools/flatzinc/mzn-gecode.bat.in" ;;
     "tools/flatzinc/mzn-gecode") CONFIG_FILES="$CONFIG_FILES tools/flatzinc/mzn-gecode:tools/flatzinc/mzn-gecode.in" ;;
+    "tools/flatzinc/gecode.msc") CONFIG_FILES="$CONFIG_FILES tools/flatzinc/gecode.msc:tools/flatzinc/gecode.msc.in" ;;
     "doxygen.conf") CONFIG_FILES="$CONFIG_FILES doxygen.conf:doxygen/doxygen.conf.in" ;;
     "doxygen.hh") CONFIG_FILES="$CONFIG_FILES doxygen.hh:doxygen/doxygen.hh.in" ;;
 

--- a/configure.ac
+++ b/configure.ac
@@ -334,6 +334,7 @@ AC_CONFIG_SUBDIRS()
 dnl @SUBDIRS@
 
 AC_SUBST(VERSION, ${PACKAGE_VERSION})
+AC_SUBST(GECODE_VERSION, ${PACKAGE_VERSION})
 AC_SUBST(DLLFLAGS, ${DLLFLAGS})
 AC_SUBST(GLDFLAGS, ${GLDFLAGS})
 AC_SUBST(ALLVIS, ${ac_gecode_vis})
@@ -374,6 +375,7 @@ else
   AC_SUBST(BATCHFILE, "")
   AC_CONFIG_FILES([tools/flatzinc/mzn-gecode:tools/flatzinc/mzn-gecode.in],[chmod +x tools/flatzinc/mzn-gecode])
 fi
+AC_CONFIG_FILES([tools/flatzinc/gecode.msc:tools/flatzinc/gecode.msc.in])
 AC_CONFIG_FILES([doxygen.conf:doxygen/doxygen.conf.in])
 AC_CONFIG_FILES([doxygen.hh:doxygen/doxygen.hh.in])
 AC_OUTPUT

--- a/configure.ac.in
+++ b/configure.ac.in
@@ -330,6 +330,7 @@ AC_CONFIG_SUBDIRS()
 dnl @SUBDIRS@
 
 AC_SUBST(VERSION, ${PACKAGE_VERSION})
+AC_SUBST(GECODE_VERSION, ${PACKAGE_VERSION})
 AC_SUBST(DLLFLAGS, ${DLLFLAGS})
 AC_SUBST(GLDFLAGS, ${GLDFLAGS})
 AC_SUBST(ALLVIS, ${ac_gecode_vis})
@@ -370,6 +371,7 @@ else
   AC_SUBST(BATCHFILE, "")
   AC_CONFIG_FILES([tools/flatzinc/mzn-gecode:tools/flatzinc/mzn-gecode.in],[chmod +x tools/flatzinc/mzn-gecode])
 fi
+AC_CONFIG_FILES([tools/flatzinc/gecode.msc:tools/flatzinc/gecode.msc.in])
 AC_CONFIG_FILES([doxygen.conf:doxygen/doxygen.conf.in])
 AC_CONFIG_FILES([doxygen.hh:doxygen/doxygen.hh.in])
 AC_OUTPUT

--- a/tools/flatzinc/gecode.msc.in
+++ b/tools/flatzinc/gecode.msc.in
@@ -1,0 +1,33 @@
+{
+  "id": "org.gecode.gecode",
+  "name": "Gecode",
+  "description": "Gecode FlatZinc executable",
+  "version": "@GECODE_VERSION@",
+  "mznlib": "../gecode",
+  "executable": "../../../bin/fzn-gecode",
+  "tags": ["cp", "int", "float", "set", "restart"],
+  "stdFlags": ["-a", "-f", "-n", "-p", "-r", "-s", "-t", "--cp-profiler"],
+  "extraFlags": [
+    ["--c-d", "Recomputation commit distance", "int", "8"],
+    ["--a-d", "Recomputation adaption distance", "int", "2"],
+    ["--decay", "Decay factor", "float", "0.99"],
+    ["--node", "Node cutoff", "int", "0"],
+    ["--fail", "Failure cutoff", "int", "0"],
+    [
+      "--restart",
+      "Restart sequence type",
+      "opt:none:constant:linear:luby:geometric",
+      "none"
+    ],
+    ["--restart-base", "Base for geometric restart sequence", "float", "1.5"],
+    ["--restart-scale", "Scale factor for restart sequence", "int", "250"],
+    ["--nogoods", "Use no-goods from restarts", "bool", "false"],
+    ["--nogoods-limit", "Depth limit for no-good extraction", "int", "128"]
+  ],
+  "supportsMzn": false,
+  "supportsFzn": true,
+  "needsSolns2Out": true,
+  "needsMznExecutable": false,
+  "needsStdlibDir": false,
+  "isGUIApplication": false
+}


### PR DESCRIPTION
This PR is to make `fzn-gecode` ready to be used with MiniZinc from the moment you `make install`. 

This is achieved by changing two things:
- A MiniZinc solver configuration with the correct version number is generated at configuration time and is installed to `PREFIX/share/minizinc/solvers/gecode.msc`
- The MiniZinc library is installed as `PREFIX/share/minizinc/gecode` instead of `PREFIX/share/gecode/mznlib`. (This is the standard location for MiniZinc libraries and where the library would be installed by the MiniZinc bundle)

Once `make install` is run you can extend `MZN_SOLVER_PATH` with `PREFIX/share/minizinc/solvers` to make the installed Gecode directly available to MiniZinc. If the `PREFIX` is a standard location, such as `/usr/local/`, then the solver configuration will immediately be detected.

These changes will make the Gecode repository more self-sufficient within the MiniZinc infrastructure and will allow developers and users to easily use different versions of Gecode with MiniZinc.

Possible future improvements might be to allow CMake/autotools to append the name/id in the configuration for custom versions of Gecode. (For now this went beyond my auto tools knowledge).