### PR TITLE
Fix CMake installation problems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -492,6 +492,7 @@ add_test(test gecode-test
   -test Search::BAB::Sol::BalGr::Binary::Binary::Binary::1::1)
 
 ## Installation Target
+include(GNUInstallDirs)
 # Install libraries and executables
 install(
   TARGETS ${GECODE_INSTALL_TARGETS}
@@ -501,12 +502,12 @@ install(
 )
 install(
   FILES ${MZN_SCRIPT}
-  DESTINATION bin
+  DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
 # Install include directory
 install(
   DIRECTORY gecode
-  DESTINATION include
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
   FILES_MATCHING
     PATTERN "**.hh"
     PATTERN "**.hpp"
@@ -523,9 +524,9 @@ install(
 # Install MiniZinc library
 install(
   DIRECTORY gecode/flatzinc/mznlib
-  DESTINATION share/minizinc/gecode
+  DESTINATION ${CMAKE_INSTALL_DATADIR}/minizinc/gecode
 )
 install(
   FILES ${PROJECT_BINARY_DIR}/tools/flatzinc/gecode.msc
-  DESTINATION share/minizinc/solvers
+  DESTINATION ${CMAKE_INSTALL_DATADIR}/minizinc/solvers
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -523,7 +523,7 @@ install(
 )
 # Install MiniZinc library
 install(
-  DIRECTORY gecode/flatzinc/mznlib
+  DIRECTORY gecode/flatzinc/mznlib/
   DESTINATION ${CMAKE_INSTALL_DATADIR}/minizinc/gecode
 )
 install(


### PR DESCRIPTION
This PR fixes 2 small problems in the CMake installation:

- ad523155c200a8f5f002f7ad39189e48b81b8cb2 started using the `GNUInstallDirs` variable, but didn't include the CMake file. This meant that if the variable was not set by the user it would default to blank (and try and create a `/gecode` directory in the root file system). I've extended the usage to all install locations can be varied using standardised cmake variables.
- The other commit fixes a problem I caused when I made the changes to generate the MiniZinc configuration file. The problem was that in CMake it would copy the `mznlib` directory into `<>/share/minizinc/gecode` instead of its contents.