### PR TITLE
Set minimum CMake version to 3.7.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@
 # CMake build script for Gecode.
 #
 
-cmake_minimum_required(VERSION 3.17)
+cmake_minimum_required(VERSION 3.7.0)
 
 project(GECODE)
 


### PR DESCRIPTION
In 3b86d0dabc371d5976c5dafef0fc7f6c5f92640b the minimum CMake version was changed to 3.17, however this is not necessary. The underlying problem with `CMP0100` was already fixed in 34dddd170ac79d71ebe1c177dc1e430d7c4d8468. It looks like #102 used master as its base which is why it was missing the fix.

Debian and Ubuntu ship older versions of CMake, so it's not really feasible to require such a new version (yet). I tested with several versions of CMake and found that 3.7.0 is the minimum compatible version (and I've tested also on 3.18.3, which was used in #96, and with 3.20.2, the latest version at the time of writing - all work fine with Gist enabled).