### PR TITLE
Fix action branching for flatzinc

### DIFF
--- a/changelog.in
+++ b/changelog.in
@@ -70,6 +70,15 @@ Date: 2020-??-??
 Let's see.
 
 [ENTRY]
+Module: flatzinc
+What:   bug
+Rank:   minor
+Thanks: Luis Quesada
+[DESCRIPTION]
+The gecode.mzn file now contains search annotation definitions for action
+branching renamed from the previous erroneous and not working activity.
+
+[ENTRY]
 Module: other
 What:   change
 Rank:   major

--- a/gecode/flatzinc/mznlib/gecode.mzn
+++ b/gecode/flatzinc/mznlib/gecode.mzn
@@ -38,10 +38,10 @@ annotation afc_min;
 annotation afc_size_min;
 annotation afc_max;
 annotation afc_size_max;
-annotation activity_min;
-annotation activity_size_min;
-annotation activity_max;
-annotation activity_size_max;
+annotation action_min;
+annotation action_size_min;
+annotation action_max;
+annotation action_size_max;
 annotation random;
 annotation int_assign(array[int] of var int: x, ann:a);
 


### PR DESCRIPTION
Action branching has support in the flatzinc driver. However, the
gecode.mzn file declared activity branching instead, which was simply
ignored.