### PR TITLE
Operators and constructors added to avoid -Wdeprecated-copy messages

### DIFF
--- a/gecode/flatzinc.hh
+++ b/gecode/flatzinc.hh
@@ -406,6 +406,8 @@ namespace Gecode { namespace FlatZinc {
                unsigned int a, int i, const FloatNumBranch& nl,
                std::ostream& o) const;
 #endif
+    /// Assignment operator
+    BranchInformation& operator =(const BranchInformation&) = default;
   };
 
   /// Uninitialized default random number generator

--- a/gecode/float.hh
+++ b/gecode/float.hh
@@ -930,6 +930,9 @@ namespace Gecode {
     /// Test whether \a n is contained in domain
     bool in(const FloatVal& n) const;
     //@}
+
+    /// Assignment operator
+    FloatVar& operator =(const FloatVar&) = default;
   };
 
   /**
@@ -1053,6 +1056,9 @@ namespace Gecode {
     GECODE_FLOAT_EXPORT
     FloatVarArray(Space& home, int n, FloatNum min, FloatNum max);
     //@}
+
+    /// Assignment operator
+    FloatVarArray& operator =(const FloatVarArray&) = default;
   };
 
 }

--- a/gecode/int.hh
+++ b/gecode/int.hh
@@ -456,6 +456,9 @@ namespace Gecode {
     /// Test whether \a n is contained in domain
     bool in(int n) const;
     //@}
+
+    /// Assignment operator
+    IntVar& operator =(const IntVar&) = default;
   };
 
   /**
@@ -588,6 +591,9 @@ namespace Gecode {
     /// Test whether domain is neither zero nor one
     bool none(void) const;
     //@}
+
+    /// Assignment operator
+    BoolVar& operator =(const BoolVar&) = default;
   };
 
   /**
@@ -699,6 +705,9 @@ namespace Gecode {
     GECODE_INT_EXPORT
     IntVarArgs(Space& home, int n, const IntSet& s);
     //@}
+
+    /// Assignment operator
+    IntVarArgs& operator =(const IntVarArgs&) = default;
   };
 
   /** \brief Passing Boolean variables
@@ -799,6 +808,9 @@ namespace Gecode {
     GECODE_INT_EXPORT
     IntVarArray(Space& home, int n, const IntSet& s);
     //@}
+
+    /// Assignment operator
+    IntVarArray& operator =(const IntVarArray&) = default;
   };
 
   /**
@@ -831,6 +843,9 @@ namespace Gecode {
     GECODE_INT_EXPORT
     BoolVarArray(Space& home, int n, int min, int max);
     //@}
+
+    /// Assignment operator
+    BoolVarArray& operator =(const BoolVarArray&) = default;
   };
 
 }

--- a/gecode/iter/ranges-inter.hpp
+++ b/gecode/iter/ranges-inter.hpp
@@ -89,6 +89,8 @@ namespace Gecode { namespace Iter { namespace Ranges {
     /// Initialize with \a n iterators in \a i
     template<class I>
     NaryInter(Region& r, I* i, int n);
+    /// Copy constructor
+    NaryInter(const NaryInter&) = default;
     /// Initialize with single iterator \a i
     template<class I>
     void init(Region& r, I& i);

--- a/gecode/iter/ranges-union.hpp
+++ b/gecode/iter/ranges-union.hpp
@@ -95,6 +95,8 @@ namespace Gecode { namespace Iter { namespace Ranges {
     /// Initialize with \a n iterators in \a i
     template<class I>
     NaryUnion(Region& r, I* i, int n);
+    /// Copy constructor
+    NaryUnion(const NaryUnion&) = default;
     /// Initialize with single iterator \a i
     template<class I>
     void init(Region& r, I& i);

--- a/gecode/kernel/data/array.hpp
+++ b/gecode/kernel/data/array.hpp
@@ -738,6 +738,9 @@ namespace Gecode {
     friend
     typename ArrayTraits<ArgArray<T>>::ArgsType
     operator + <>(const T& x, const ArgArray<T>& y);
+
+    /// Assignment operator
+    ArgArray& operator =(const ArgArray&) = default;
   };
 
   template<class> class VarArgArray;
@@ -825,6 +828,9 @@ namespace Gecode {
     friend
     typename ArrayTraits<VarArgArray<Var>>::ArgsType
     operator + <>(const Var& x, const VarArgArray<Var>& y);
+
+    /// Assignment operator
+    VarArgArray& operator =(const VarArgArray&) = default;
   };
 
 

--- a/gecode/kernel/data/shared-array.hpp
+++ b/gecode/kernel/data/shared-array.hpp
@@ -158,6 +158,9 @@ namespace Gecode {
     /// Return a reverse and read-only iterator past the beginning of the array
     const_reverse_iterator rend(void) const;
     //@}
+
+    /// Assignment operator
+    SharedArray& operator =(const SharedArray&) = default;
   };
 
   /**

--- a/gecode/set.hh
+++ b/gecode/set.hh
@@ -258,6 +258,9 @@ namespace Gecode {
     /// Test whether \a i is not in the least upper bound
     bool notContains(int i) const;
     //@}
+
+    /// Assignment operator
+    SetVar& operator =(const SetVar&) = default;
   };
 
   /**
@@ -621,6 +624,9 @@ namespace Gecode {
                 unsigned int minCard = 0,
                 unsigned int maxCard = Set::Limits::card);
     //@}
+
+    /// Assignment operator
+    SetVarArray& operator =(const SetVarArray&) = default;
   };
 
 }


### PR DESCRIPTION
These two commits:

1) add default copy assignment operators where their implicit definition is now (C++11) deprecated due to the presence of user-declared copy constructors.

2) add default copy constructors where their implicit definition is now (C++11) deprecated due to the presence of user-declared copy assignment operators.

This eliminates the warning messages which come from `-Wdeprecated-copy` (controlled by `-Wextra`). These warning messages form the bulk of those highlighted in Issue #118.
