### PR TITLE
Include MiniZinc solver configuration for Gecode Gist

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -474,6 +474,13 @@ configure_file(
   ${PROJECT_BINARY_DIR}/tools/flatzinc/gecode.msc
   @ONLY
 )
+if (GECODE_HAS_GIST)
+	configure_file(
+		${PROJECT_SOURCE_DIR}/tools/flatzinc/gecode-gist.msc.in
+		${PROJECT_BINARY_DIR}/tools/flatzinc/gecode-gist.msc
+		@ONLY
+	)
+endif()
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
@@ -530,3 +537,9 @@ install(
   FILES ${PROJECT_BINARY_DIR}/tools/flatzinc/gecode.msc
   DESTINATION ${CMAKE_INSTALL_DATADIR}/minizinc/solvers
 )
+if (GECODE_HAS_GIST)
+	install(
+		FILES ${PROJECT_BINARY_DIR}/tools/flatzinc/gecode-gist.msc
+		DESTINATION share/minizinc/solvers
+	)
+endif()

--- a/Makefile.in
+++ b/Makefile.in
@@ -845,7 +845,11 @@ export FLATZINCSTATICLIB	= $(LIBPREFIX)@FLATZINC@$(STATICLIBSUFFIX)
 export FLATZINCLIB		= $(LIBPREFIX)@FLATZINC@$(LIBSUFFIX)
 export LINKFLATZINC		= $(LINKPREFIX)@FLATZINC@$(LINKSUFFIX)
 export FLATZINCMZNLIB		= gecode/flatzinc/mznlib
+ifeq "@enable_gist@" "yes"
+export FLATZINCCONFIG		= tools/flatzinc/gecode.msc tools/flatzinc/gecode-gist.msc
+else
 export FLATZINCCONFIG		= tools/flatzinc/gecode.msc
+endif
 FLATZINCEXE	= tools/flatzinc/fzn-gecode$(EXESUFFIX)
 ifeq "@need_soname@" "yes"
 export FLATZINCSONAME = @WLSONAME@$(LIBPREFIX)@FLATZINC@$(SOSUFFIX)
@@ -1972,7 +1976,7 @@ endif
 
 endif
 
-doinstallheaders: $(ALLHDR:%=$(top_srcdir)/%) $(EXTRA_HEADERS) $(VARIMPHDR)
+doinstallheaders: $(ALLHDR:%=$(top_srcdir)/%) $(EXTRA_HEADERS) $(VARIMPHDR) $(FLATZINCCONFIG)
 	mkdir -p $(DESTDIR)$(includedir) && \
 	(cd $(top_srcdir) && tar cf - $(ALLHDR)) | \
 	  (cd $(DESTDIR)$(includedir) && tar xf -) && \
@@ -1982,9 +1986,11 @@ doinstallheaders: $(ALLHDR:%=$(top_srcdir)/%) $(EXTRA_HEADERS) $(VARIMPHDR)
 	for_extraheaders="$(EXTRA_HEADERS)" && \
 	  for f in $$for_extraheaders; do \
 	    cp $$f $(DESTDIR)$(includedir)/$$f; done && \
+	mkdir -p $(DESTDIR)$(datadir)/minizinc/solvers && \
+	for_flatconf="$(FLATZINCCONFIG)" && \
+	  for f in $$for_flatconf; do \
+			cp $$f $(DESTDIR)$(datadir)/minizinc/solvers; done && \
 	for_mznlib="$(FLATZINCMZNLIB)" && \
-	  mkdir -p $(DESTDIR)$(datadir)/minizinc/solvers; \
-      cp $(FLATZINCCONFIG) $(DESTDIR)$(datadir)/minizinc/solvers/; \
 	  mkdir -p $(DESTDIR)$(datadir)/minizinc/gecode; \
 	  for f in $$for_mznlib; do \
 		cp $(top_srcdir)/$$f/*.mzn \

--- a/changelog.in
+++ b/changelog.in
@@ -70,6 +70,14 @@ Date: 2020-??-??
 Let's see.
 
 [ENTRY]
+Module: flatzinc 
+What:   new
+Rank:   minor
+Thanks: Jip J. Dekker
+[DESCRIPTION]
+Generate MiniZinc solver configuration for the Gecode FlatZinc using Gist.
+
+[ENTRY]
 Module: search
 What:   new
 Rank:   minor

--- a/configure
+++ b/configure
@@ -13433,6 +13433,8 @@ else
 fi
 ac_config_files="$ac_config_files tools/flatzinc/gecode.msc:tools/flatzinc/gecode.msc.in"
 
+ac_config_files="$ac_config_files tools/flatzinc/gecode-gist.msc:tools/flatzinc/gecode-gist.msc.in"
+
 ac_config_files="$ac_config_files doxygen.conf:doxygen/doxygen.conf.in"
 
 ac_config_files="$ac_config_files doxygen.hh:doxygen/doxygen.hh.in"
@@ -14131,6 +14133,7 @@ do
     "tools/flatzinc/mzn-gecode.bat") CONFIG_FILES="$CONFIG_FILES tools/flatzinc/mzn-gecode.bat:tools/flatzinc/mzn-gecode.bat.in" ;;
     "tools/flatzinc/mzn-gecode") CONFIG_FILES="$CONFIG_FILES tools/flatzinc/mzn-gecode:tools/flatzinc/mzn-gecode.in" ;;
     "tools/flatzinc/gecode.msc") CONFIG_FILES="$CONFIG_FILES tools/flatzinc/gecode.msc:tools/flatzinc/gecode.msc.in" ;;
+    "tools/flatzinc/gecode-gist.msc") CONFIG_FILES="$CONFIG_FILES tools/flatzinc/gecode-gist.msc:tools/flatzinc/gecode-gist.msc.in" ;;
     "doxygen.conf") CONFIG_FILES="$CONFIG_FILES doxygen.conf:doxygen/doxygen.conf.in" ;;
     "doxygen.hh") CONFIG_FILES="$CONFIG_FILES doxygen.hh:doxygen/doxygen.hh.in" ;;
 

--- a/configure.ac
+++ b/configure.ac
@@ -376,6 +376,7 @@ else
   AC_CONFIG_FILES([tools/flatzinc/mzn-gecode:tools/flatzinc/mzn-gecode.in],[chmod +x tools/flatzinc/mzn-gecode])
 fi
 AC_CONFIG_FILES([tools/flatzinc/gecode.msc:tools/flatzinc/gecode.msc.in])
+AC_CONFIG_FILES([tools/flatzinc/gecode-gist.msc:tools/flatzinc/gecode-gist.msc.in])
 AC_CONFIG_FILES([doxygen.conf:doxygen/doxygen.conf.in])
 AC_CONFIG_FILES([doxygen.hh:doxygen/doxygen.hh.in])
 AC_OUTPUT

--- a/configure.ac.in
+++ b/configure.ac.in
@@ -372,6 +372,7 @@ else
   AC_CONFIG_FILES([tools/flatzinc/mzn-gecode:tools/flatzinc/mzn-gecode.in],[chmod +x tools/flatzinc/mzn-gecode])
 fi
 AC_CONFIG_FILES([tools/flatzinc/gecode.msc:tools/flatzinc/gecode.msc.in])
+AC_CONFIG_FILES([tools/flatzinc/gecode-gist.msc:tools/flatzinc/gecode-gist.msc.in])
 AC_CONFIG_FILES([doxygen.conf:doxygen/doxygen.conf.in])
 AC_CONFIG_FILES([doxygen.hh:doxygen/doxygen.hh.in])
 AC_OUTPUT

--- a/tools/flatzinc/gecode-gist.msc.in
+++ b/tools/flatzinc/gecode-gist.msc.in
@@ -1,0 +1,34 @@
+{
+  "id": "org.gecode.gist",
+  "name": "Gecode Gist",
+  "description": "Gecode FlatZinc executable",
+  "version": "@GECODE_VERSION@",
+  "mznlib": "../gecode",
+  "executable": ["../../../bin/fzn-gecode", "-mode", "gist"],
+  "tags": ["cp", "int", "float", "set", "restart"],
+  "stdFlags": ["-a", "-f", "-n", "-p", "-r", "-s", "-t", "--cp-profiler"],
+  "extraFlags": [
+    ["--c-d", "Recomputation commit distance", "int", "8"],
+    ["--a-d", "Recomputation adaption distance", "int", "2"],
+    ["--decay", "Decay factor", "float", "0.99"],
+    ["--node", "Node cutoff", "int", "0"],
+    ["--fail", "Failure cutoff", "int", "0"],
+    [
+      "--restart",
+      "Restart sequence type",
+      "opt:none:constant:linear:luby:geometric",
+      "none"
+    ],
+    ["--restart-base", "Base for geometric restart sequence", "float", "1.5"],
+    ["--restart-scale", "Scale factor for restart sequence", "int", "250"],
+    ["--restart-limit", "Restart cutoff", "int", "0"],
+    ["--nogoods", "Use no-goods from restarts", "bool", "false"],
+    ["--nogoods-limit", "Depth limit for no-good extraction", "int", "128"]
+  ],
+  "supportsMzn": false,
+  "supportsFzn": true,
+  "needsSolns2Out": true,
+  "needsMznExecutable": false,
+  "needsStdlibDir": false,
+  "isGUIApplication": true 
+}


### PR DESCRIPTION
This PR adds an additional MiniZinc solver configuration when you compile and install Gecode with Gist available. This extra solver configuration allows you to open the gist window directly from MiniZinc.

This idea is already included in the MiniZinc bundle, but I think it would be good to make it available if you install Gecode directly.

A downside of the approach taken is that it still uses a separate template for each configuration file (even though most of the file is shared). However, this seemed the only reasonable approach with autoconf.