### PR TITLE
Replace using statement with typedef to fix Windows Gist compilation

### DIFF
--- a/gecode/kernel/branch/val-sel.hpp
+++ b/gecode/kernel/branch/val-sel.hpp
@@ -67,8 +67,9 @@ namespace Gecode {
                   typename BranchTraits<typename View::VarType>::ValType> {
   public:
     /// The corresponding variable type
-    using typename ValSel<View,
-                          typename BranchTraits<typename View::VarType>::ValType>::Var;
+    typedef typename ValSel<View,
+                            typename BranchTraits<typename View::VarType>
+                              ::ValType>::Var Var;
     /// The corresponding value type
     typedef typename ValSel<View,
                             typename BranchTraits<typename View::VarType>


### PR DESCRIPTION
The using statement causes Gecode Gist compilation to fail on Windows with VS2019 and Qt 6.2.1:

```
gecode/kernel/branch/val-sel.hpp(118): error C2244: 'Gecode::ValSelFunction<View>::ValSelFunction': unable to match function definition to an existing declaration
gecode/kernel/branch/val-sel.hpp(116): note: see declaration of 'Gecode::ValSelFunction<View>::ValSelFunction'
gecode/kernel/branch/val-sel.hpp(118): note: definition
gecode/kernel/branch/val-sel.hpp(118): note: 'Gecode::ValSelFunction<View>::ValSelFunction(Gecode::Space &,const Gecode::ValBranch<Gecode::Var> &)'
gecode/kernel/branch/val-sel.hpp(118): note: existing declarations
gecode/kernel/branch/val-sel.hpp(118): note: 'Gecode::ValSelFunction<View>::ValSelFunction(Gecode::Space &,Gecode::ValSelFunction<View> &)'
gecode/kernel/branch/val-sel.hpp(118): note: 'Gecode::ValSelFunction<View>::ValSelFunction(Gecode::Space &,const Gecode::ValBranch<ValSelFunction<View>::ValSel<View,BranchTraits<View::VarType>::ValType>::Var> &)'
```

This seems like it may be a bug in MSVC, which resolves `Var` to `Gecode::Var` in the constructor for `ValSelFunction` instead of `Gecode::ValSelFunction<View>::Var`.

It also does not happen with Qt 5.12.9, or without Gist, although I don't see how changing the Qt version could cause this problem.