### PR TITLE
Fix the int_pow decomposition when using potentially negative exponents

### DIFF
--- a/changelog.in
+++ b/changelog.in
@@ -70,6 +70,17 @@ Date: 2020-??-??
 Let's see.
 
 [ENTRY]
+Module: flatzinc
+What:   bug
+Rank:   minor
+Thanks: Jip J. Dekker
+[DESCRIPTION]
+The FlatZinc decomposition of "int_pow" would use a zero default value for the
+base even raised to a negative value, causing unsatisfiability. The fix
+introduces a simpler decomposition that moves the default values for impossible
+exponent values to the result.
+
+[ENTRY]
 Module: other
 What:   bug
 Rank:   minor

--- a/gecode/flatzinc/mznlib/redefinitions.mzn
+++ b/gecode/flatzinc/mznlib/redefinitions.mzn
@@ -83,10 +83,10 @@ predicate gecode_int_pow(var int: x, int: y, var int: z);
 predicate int_pow(var int: x, var int: y, var int: z) =
     if is_fixed(y) then gecode_int_pow(x,fix(y),z)
     else let {
-        array[lb(y)..ub(y)] of var int: pow_x = array1d(lb(y)..ub(y),
-          [if y=i then x else 0 endif | i in lb(y)..ub(y)]);
-        array[lb(y)..ub(y)] of var int: pow_table = array1d(lb(y)..ub(y),
-          [pow(pow_x[i],i) | i in lb(y)..ub(y)]);
+        array[lb(y)..ub(y)] of var int: pow_table = [
+            i: if i in dom(y) then pow(x, i) else lb(z) endif
+            | i in lb(y)..ub(y)
+        ];
     } in z=pow_table[y]
     endif;
 


### PR DESCRIPTION
The FlatZinc decomposition of "int_pow" would use a zero default value for the base even raised to a negative value, causing unsatisfiability. This PR introduces a simpler decomposition that moves the default values for impossible
exponent values to the result.