### PR TITLE
Add redefinition for `int_pow_fixed`

### DIFF
--- a/changelog.in
+++ b/changelog.in
@@ -81,6 +81,15 @@ introduces a simpler decomposition that moves the default values for impossible
 exponent values to the result.
 
 [ENTRY]
+Module: flatzinc
+What:   change
+Rank:   minor
+Thanks: Jason Nguyen
+[DESCRIPTION]
+Rewrite "int_pow_fixed" into "gecode_int_pow" rather than using the default
+MiniZinc decomposition.
+
+[ENTRY]
 Module: other
 What:   bug
 Rank:   minor

--- a/gecode/flatzinc/mznlib/redefinitions-2.2.1.mzn
+++ b/gecode/flatzinc/mznlib/redefinitions-2.2.1.mzn
@@ -1,0 +1,14 @@
+predicate gecode_int_pow(var int: x, int: y, var int: z);
+
+predicate int_pow_fixed(var int: x, int: y, var int: z) =
+  if y = 0 then
+    z = 1
+  elseif y = 1 then
+    z = x
+  else
+    if y >= 0 then
+      gecode_int_pow(x, y, z)
+    else
+      z = 1 div pow(x, -y)
+    endif
+  endif;

--- a/gecode/flatzinc/mznlib/redefinitions.mzn
+++ b/gecode/flatzinc/mznlib/redefinitions.mzn
@@ -78,17 +78,13 @@ predicate array_var_float_element(var int: b, array[int] of var float: as, var f
     b in index_set(as) /\
     forall(d in index_set(as))( b = d -> as[d] = c );
 
-predicate gecode_int_pow(var int: x, int: y, var int: z);
-
 predicate int_pow(var int: x, var int: y, var int: z) =
-    if is_fixed(y) then gecode_int_pow(x,fix(y),z)
-    else let {
+    let {
         array[lb(y)..ub(y)] of var int: pow_table = [
-            i: if i in dom(y) then pow(x, i) else lb(z) endif
+            i: if i in dom(y) then pow(x, i) default lb(z) else lb(z) endif
             | i in lb(y)..ub(y)
         ];
-    } in z=pow_table[y]
-    endif;
+    } in z = pow_table[y];
 
 predicate array_bool_and_imp(array [int] of var bool: as, var bool: r);
 predicate array_bool_or_imp(array [int] of var bool: as, var bool: r);


### PR DESCRIPTION
Previously the default MiniZinc decomposition into `product` was used instead of `gecode_int_pow`.