### PR TITLE
Fixing parallel engine memory leak for issue #156

### DIFF
--- a/changelog.in
+++ b/changelog.in
@@ -70,6 +70,17 @@ Date: 2020-??-??
 Let's see.
 
 [ENTRY]
+Module: search
+What:   bug
+Rank:   minor
+Thanks: Alexis LG
+Issue:  156
+[DESCRIPTION]
+The parallel search engines could in some cases leak memory, when multiple
+solutions are produced but not consumed. The fix clears the queue of solutions
+on destruction.
+
+[ENTRY]
 Module: flatzinc
 What:   bug
 Rank:   minor

--- a/gecode/search/par/engine.hh
+++ b/gecode/search/par/engine.hh
@@ -193,6 +193,9 @@ namespace Gecode { namespace Search { namespace Par {
     /// Check whether engine has been stopped
     virtual bool stopped(void) const;
     //@}
+
+    /// Destructor
+    virtual ~Engine(void);
   };
 
 }}}

--- a/gecode/search/par/engine.hpp
+++ b/gecode/search/par/engine.hpp
@@ -361,6 +361,15 @@ namespace Gecode { namespace Search { namespace Par {
     tracer.done();
   }
 
+  /*
+   * Destructor
+   */
+  template<class Tracer>
+  Engine<Tracer>::~Engine(void) {
+    while (!solutions.empty())
+      delete solutions.pop();
+  }
+
 }}}
 
 // STATISTICS: search-par


### PR DESCRIPTION
This fix proceeds by cleaning the `Gecode::Support::DynamicQueue<Gecode::Space *, Gecode::Heap> solutions` attribute of the `Gecode::Search::Par::Engine<Tracer>` class in the destructor. It unstacks the remaining `Gecode::Space *` items of the queue and explicitly deletes the objects until the queue is empty.

This fix uses the same mechanism as of `gecode/search/par/pbs.hpp` [https://github.com/Gecode/gecode/blob/b38d85179280490b228665738c526eac31f03d9e/gecode/search/par/pbs.hpp](https://github.com/Gecode/gecode/blob/b38d85179280490b228665738c526eac31f03d9e/gecode/search/par/pbs.hpp), which deals with the same `solutions` attribute :
```cpp
  forceinline
  CollectAll::~CollectAll(void) {
    while (!solutions.empty())
      delete solutions.pop();
  }
```