### PR TITLE
Remove `RBS::shared_info`.

### DIFF
--- a/gecode/search/seq/rbs.hh
+++ b/gecode/search/seq/rbs.hh
@@ -83,8 +83,6 @@ namespace Gecode { namespace Search { namespace Seq {
     RestartStop* stop;
     /// How many solutions since the last restart
     unsigned long int sslr;
-    /// Whether the slave can share info (AFC) with the master
-    bool shared_info;
     /// Whether search for the next solution will be complete
     bool complete;
     /// Whether a restart must be performed when next is called


### PR DESCRIPTION
This was added in 8ee34b115b59a8155588001d915868ebbebc5449 and the code that used it has since been removed. The field was no longer being initialized.