### PR TITLE
Always use `unordered_map`.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -220,21 +220,6 @@ else ()
   set(GECODE_USE_CLOCK 1)
 endif ()
 
-include(CheckCXXSourceCompiles)
-check_cxx_source_compiles("
-   #include <ext/hash_map>
-   int main() {}" HAVE_EXT_HASH_MAP)
-if (HAVE_EXT_HASH_MAP)
-  set(GECODE_HAS_GNU_HASH_MAP "/**/")
-endif ()
-
-check_cxx_source_compiles("
-   #include <unordered_map>
-   int main() {}" HAVE_UNORDERED_MAP)
-if (HAVE_UNORDERED_MAP)
-  set(GECODE_HAS_UNORDERED_MAP "/**/")
-endif ()
-
 # Check for inline.
 include(CheckCSourceCompiles)
 check_c_source_compiles("

--- a/configure
+++ b/configure
@@ -11769,24 +11769,6 @@ fi
   ;;
 esac
 
-ac_fn_cxx_check_header_mongrel "$LINENO" "ext/hash_map" "ac_cv_header_ext_hash_map" "$ac_includes_default"
-if test "x$ac_cv_header_ext_hash_map" = xyes; then :
-
-$as_echo "#define GECODE_HAS_GNU_HASH_MAP /**/" >>confdefs.h
-
-fi
-
-
-
-ac_fn_cxx_check_header_mongrel "$LINENO" "unordered_map" "ac_cv_header_unordered_map" "$ac_includes_default"
-if test "x$ac_cv_header_unordered_map" = xyes; then :
-
-$as_echo "#define GECODE_HAS_UNORDERED_MAP /**/" >>confdefs.h
-
-fi
-
-
-
 
    # Check whether --enable-doc-dot was given.
 if test "${enable_doc_dot+set}" = set; then :

--- a/configure.ac
+++ b/configure.ac
@@ -227,16 +227,6 @@ microsoft)
   ;;
 esac
 
-dnl check whether we can use GNU hash_map
-AC_CHECK_HEADER([ext/hash_map],
-  [AC_DEFINE([GECODE_HAS_GNU_HASH_MAP],[],
-             [Whether GNU hash_map is available])])
-
-dnl check whether we can use unordered_map
-AC_CHECK_HEADER([unordered_map],
-  [AC_DEFINE([GECODE_HAS_UNORDERED_MAP],[],
-             [Whether unordered_map is available])])
-
 dnl find out what parts the user wants to build
 
 AC_GECODE_DOC_SWITCHES

--- a/configure.ac.in
+++ b/configure.ac.in
@@ -223,16 +223,6 @@ microsoft)
   ;;
 esac
 
-dnl check whether we can use GNU hash_map
-AC_CHECK_HEADER([ext/hash_map],
-  [AC_DEFINE([GECODE_HAS_GNU_HASH_MAP],[],
-             [Whether GNU hash_map is available])])
-
-dnl check whether we can use unordered_map
-AC_CHECK_HEADER([unordered_map],
-  [AC_DEFINE([GECODE_HAS_UNORDERED_MAP],[],
-             [Whether unordered_map is available])])
-
 dnl find out what parts the user wants to build
 
 AC_GECODE_DOC_SWITCHES

--- a/gecode/flatzinc/symboltable.hh
+++ b/gecode/flatzinc/symboltable.hh
@@ -34,15 +34,8 @@
 #ifndef GECODE_FLATZINC_SYMBOLTABLE_HH
 #define GECODE_FLATZINC_SYMBOLTABLE_HH
 
-#include <vector>
-
-#ifdef GECODE_HAS_UNORDERED_MAP
 #include <unordered_map>
-#elif defined(GECODE_HAS_GNU_HASH_MAP)
-#include <ext/hash_map>
-#else
-#include <map>
-#endif
+#include <vector>
 
 namespace Gecode { namespace FlatZinc {
 
@@ -50,20 +43,7 @@ namespace Gecode { namespace FlatZinc {
   template<class Val>
   class SymbolTable {
   private:
-#ifdef GECODE_HAS_UNORDERED_MAP
-    typedef std::unordered_map<std::string,Val> mymap;
-#elif defined(GECODE_HAS_GNU_HASH_MAP)
-    class hashString {
-    public:
-      size_t operator ()(const std::string& x) const {
-        return __gnu_cxx::hash<const char*>()(x.c_str());
-      }
-    };
-    typedef __gnu_cxx::hash_map<std::string,Val,hashString> mymap;
-#else
-    typedef std::map<std::string,Val> mymap;
-#endif
-    mymap m;
+    std::unordered_map<std::string,Val> m;
   public:
     /// Insert \a val with \a key
     bool put(const std::string& key, const Val& val);
@@ -74,7 +54,7 @@ namespace Gecode { namespace FlatZinc {
   template<class Val>
   bool
   SymbolTable<Val>::put(const std::string& key, const Val& val) {
-    typename mymap::const_iterator i = m.find(key);
+    const auto& i = m.find(key);
     bool fresh = (i == m.end());
     m[key] = val;
     return fresh;
@@ -83,7 +63,7 @@ namespace Gecode { namespace FlatZinc {
   template<class Val>
   bool
   SymbolTable<Val>::get(const std::string& key, Val& val) const {
-    typename mymap::const_iterator i = m.find(key);
+    const auto& i = m.find(key);
     if (i == m.end())
       return false;
     val = i->second;

--- a/gecode/support/config.hpp.in
+++ b/gecode/support/config.hpp.in
@@ -72,9 +72,6 @@
 /* Whether Gist is available */
 #undef GECODE_HAS_GIST
 
-/* Whether GNU hash_map is available */
-#undef GECODE_HAS_GNU_HASH_MAP
-
 /* Whether to build INT variables */
 #undef GECODE_HAS_INT_VARS
 
@@ -89,9 +86,6 @@
 
 /* Whether to build SET variables */
 #undef GECODE_HAS_SET_VARS
-
-/* Whether unordered_map is available */
-#undef GECODE_HAS_UNORDERED_MAP
 
 /* Gecode version */
 #undef GECODE_LIBRARY_VERSION


### PR DESCRIPTION
`ext/hash_map` has been deprecated in some compilers that supported it and `std::unordered_map` is part of C++11 and we require C++17.