### PR TITLE
Update `Makefile.dep`

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -29479,6 +29479,766 @@ test/flatzinc/cumulatives$(OBJSUFFIX) test/flatzinc/cumulatives$(SBJSUFFIX): \
 	./gecode/support/static-stack.hpp ./gecode/support/thread.hpp ./gecode/support/thread/thread.hpp \
 	./gecode/support/timer.hpp ./test/flatzinc.hh ./test/test.hh \
 	./test/test.hpp 
+test/flatzinc/cumulatives_full_1$(OBJSUFFIX) test/flatzinc/cumulatives_full_1$(SBJSUFFIX): \
+	./gecode/driver.hh ./gecode/driver/options.hpp ./gecode/driver/script.hpp \
+	./gecode/flatzinc.hh ./gecode/flatzinc/ast.hh ./gecode/flatzinc/conexpr.hh \
+	./gecode/flatzinc/option.hh ./gecode/flatzinc/varspec.hh ./gecode/float.hh \
+	./gecode/float/array-traits.hpp ./gecode/float/array.hpp ./gecode/float/branch.hpp \
+	./gecode/float/branch/action.hpp ./gecode/float/branch/afc.hpp ./gecode/float/branch/assign.hpp \
+	./gecode/float/branch/chb.hpp ./gecode/float/branch/traits.hpp ./gecode/float/branch/val.hpp \
+	./gecode/float/branch/var.hpp ./gecode/float/channel.hpp ./gecode/float/exception.hpp \
+	./gecode/float/limits.hpp ./gecode/float/nextafter.hpp ./gecode/float/num.hpp \
+	./gecode/float/rounding.hpp ./gecode/float/trace.hpp ./gecode/float/trace/delta.hpp \
+	./gecode/float/trace/trace-view.hpp ./gecode/float/trace/traits.hpp ./gecode/float/val.hpp \
+	./gecode/float/var-imp.hpp ./gecode/float/var-imp/delta.hpp ./gecode/float/var-imp/float.hpp \
+	./gecode/float/var/float.hpp ./gecode/float/var/print.hpp ./gecode/float/view.hpp \
+	./gecode/float/view/float.hpp ./gecode/float/view/minus.hpp ./gecode/float/view/offset.hpp \
+	./gecode/float/view/print.hpp ./gecode/float/view/rel-test.hpp ./gecode/float/view/scale.hpp \
+	./gecode/gist.hh ./gecode/gist/gist.hpp ./gecode/int.hh \
+	./gecode/int/array-traits.hpp ./gecode/int/array.hpp ./gecode/int/branch.hpp \
+	./gecode/int/branch/action.hpp ./gecode/int/branch/afc.hpp ./gecode/int/branch/assign.hpp \
+	./gecode/int/branch/chb.hpp ./gecode/int/branch/traits.hpp ./gecode/int/branch/val.hpp \
+	./gecode/int/branch/var.hpp ./gecode/int/channel.hpp ./gecode/int/div.hh \
+	./gecode/int/div.hpp ./gecode/int/exception.hpp ./gecode/int/extensional.hpp \
+	./gecode/int/extensional/dfa.hpp ./gecode/int/extensional/tuple-set.hpp ./gecode/int/int-set-1.hpp \
+	./gecode/int/int-set-2.hpp ./gecode/int/ipl.hpp ./gecode/int/irt.hpp \
+	./gecode/int/limits.hpp ./gecode/int/propagator.hpp ./gecode/int/reify.hpp \
+	./gecode/int/trace.hpp ./gecode/int/trace/bool-delta.hpp ./gecode/int/trace/bool-trace-view.hpp \
+	./gecode/int/trace/int-delta.hpp ./gecode/int/trace/int-trace-view.hpp ./gecode/int/trace/traits.hpp \
+	./gecode/int/var-imp.hpp ./gecode/int/var-imp/bool.hpp ./gecode/int/var-imp/delta.hpp \
+	./gecode/int/var-imp/int.hpp ./gecode/int/var/bool.hpp ./gecode/int/var/int.hpp \
+	./gecode/int/var/print.hpp ./gecode/int/view.hpp ./gecode/int/view/bool-test.hpp \
+	./gecode/int/view/bool.hpp ./gecode/int/view/cached.hpp ./gecode/int/view/constint.hpp \
+	./gecode/int/view/int.hpp ./gecode/int/view/iter.hpp ./gecode/int/view/minus.hpp \
+	./gecode/int/view/neg-bool.hpp ./gecode/int/view/offset.hpp ./gecode/int/view/print.hpp \
+	./gecode/int/view/rel-test.hpp ./gecode/int/view/scale.hpp ./gecode/int/view/zero.hpp \
+	./gecode/iter.hh ./gecode/iter/ranges-add.hpp ./gecode/iter/ranges-append.hpp \
+	./gecode/iter/ranges-array.hpp ./gecode/iter/ranges-cache.hpp ./gecode/iter/ranges-compl.hpp \
+	./gecode/iter/ranges-diff.hpp ./gecode/iter/ranges-empty.hpp ./gecode/iter/ranges-inter.hpp \
+	./gecode/iter/ranges-list.hpp ./gecode/iter/ranges-map.hpp ./gecode/iter/ranges-minmax.hpp \
+	./gecode/iter/ranges-minus.hpp ./gecode/iter/ranges-negative.hpp ./gecode/iter/ranges-offset.hpp \
+	./gecode/iter/ranges-operations.hpp ./gecode/iter/ranges-positive.hpp ./gecode/iter/ranges-rangelist.hpp \
+	./gecode/iter/ranges-scale.hpp ./gecode/iter/ranges-singleton-append.hpp ./gecode/iter/ranges-singleton.hpp \
+	./gecode/iter/ranges-size.hpp ./gecode/iter/ranges-union.hpp ./gecode/iter/ranges-values.hpp \
+	./gecode/iter/values-array.hpp ./gecode/iter/values-bitset.hpp ./gecode/iter/values-bitsetoffset.hpp \
+	./gecode/iter/values-inter.hpp ./gecode/iter/values-list.hpp ./gecode/iter/values-map.hpp \
+	./gecode/iter/values-minus.hpp ./gecode/iter/values-negative.hpp ./gecode/iter/values-offset.hpp \
+	./gecode/iter/values-positive.hpp ./gecode/iter/values-ranges.hpp ./gecode/iter/values-singleton.hpp \
+	./gecode/iter/values-union.hpp ./gecode/iter/values-unique.hpp ./gecode/kernel.hh \
+	./gecode/kernel/archive.hpp ./gecode/kernel/branch/action.hpp ./gecode/kernel/branch/afc.hpp \
+	./gecode/kernel/branch/chb.hpp ./gecode/kernel/branch/filter.hpp ./gecode/kernel/branch/merit.hpp \
+	./gecode/kernel/branch/print.hpp ./gecode/kernel/branch/tiebreak.hpp ./gecode/kernel/branch/traits.hpp \
+	./gecode/kernel/branch/val-commit.hpp ./gecode/kernel/branch/val-sel-commit.hpp ./gecode/kernel/branch/val-sel.hpp \
+	./gecode/kernel/branch/val.hpp ./gecode/kernel/branch/var.hpp ./gecode/kernel/branch/view-sel.hpp \
+	./gecode/kernel/branch/view-val.hpp ./gecode/kernel/branch/view.hpp ./gecode/kernel/core.hpp \
+	./gecode/kernel/data/array.hpp ./gecode/kernel/data/rnd.hpp ./gecode/kernel/data/shared-array.hpp \
+	./gecode/kernel/data/shared-data.hpp ./gecode/kernel/exception.hpp ./gecode/kernel/gpi.hpp \
+	./gecode/kernel/macros.hpp ./gecode/kernel/memory/allocators.hpp ./gecode/kernel/memory/config.hpp \
+	./gecode/kernel/memory/manager.hpp ./gecode/kernel/memory/region.hpp ./gecode/kernel/modevent.hpp \
+	./gecode/kernel/propagator/advisor.hpp ./gecode/kernel/propagator/pattern.hpp ./gecode/kernel/propagator/subscribed.hpp \
+	./gecode/kernel/propagator/wait.hpp ./gecode/kernel/range-list.hpp ./gecode/kernel/shared-object.hpp \
+	./gecode/kernel/shared-space-data.hpp ./gecode/kernel/trace/filter.hpp ./gecode/kernel/trace/general.hpp \
+	./gecode/kernel/trace/print.hpp ./gecode/kernel/trace/recorder.hpp ./gecode/kernel/trace/tracer.hpp \
+	./gecode/kernel/trace/traits.hpp ./gecode/kernel/var-imp.hpp ./gecode/kernel/var-type.hpp \
+	./gecode/kernel/var.hpp ./gecode/kernel/view.hpp ./gecode/minimodel.hh \
+	./gecode/minimodel/aliases.hpp ./gecode/minimodel/bool-expr.hpp ./gecode/minimodel/channel.hpp \
+	./gecode/minimodel/exception.hpp ./gecode/minimodel/float-expr.hpp ./gecode/minimodel/float-rel.hpp \
+	./gecode/minimodel/int-expr.hpp ./gecode/minimodel/int-rel.hpp ./gecode/minimodel/ipl.hpp \
+	./gecode/minimodel/ldsb.hpp ./gecode/minimodel/matrix.hpp ./gecode/minimodel/optimize.hpp \
+	./gecode/minimodel/reg.hpp ./gecode/minimodel/set-expr.hpp ./gecode/minimodel/set-rel.hpp \
+	./gecode/search.hh ./gecode/search/bab.hpp ./gecode/search/base.hpp \
+	./gecode/search/build.hpp ./gecode/search/cutoff.hpp ./gecode/search/dfs.hpp \
+	./gecode/search/engine.hpp ./gecode/search/exception.hpp ./gecode/search/lds.hpp \
+	./gecode/search/options.hpp ./gecode/search/pbs.hpp ./gecode/search/rbs.hpp \
+	./gecode/search/sebs.hpp ./gecode/search/seq/dead.hh ./gecode/search/statistics.hpp \
+	./gecode/search/stop.hpp ./gecode/search/support.hh ./gecode/search/trace-recorder.hpp \
+	./gecode/search/tracer.hpp ./gecode/search/traits.hpp ./gecode/set.hh \
+	./gecode/set/array-traits.hpp ./gecode/set/array.hpp ./gecode/set/branch.hpp \
+	./gecode/set/branch/action.hpp ./gecode/set/branch/afc.hpp ./gecode/set/branch/assign.hpp \
+	./gecode/set/branch/chb.hpp ./gecode/set/branch/traits.hpp ./gecode/set/branch/val.hpp \
+	./gecode/set/branch/var.hpp ./gecode/set/exception.hpp ./gecode/set/int.hpp \
+	./gecode/set/limits.hpp ./gecode/set/trace.hpp ./gecode/set/trace/delta.hpp \
+	./gecode/set/trace/trace-view.hpp ./gecode/set/trace/traits.hpp ./gecode/set/var-imp.hpp \
+	./gecode/set/var-imp/delta.hpp ./gecode/set/var-imp/integerset.hpp ./gecode/set/var-imp/iter.hpp \
+	./gecode/set/var-imp/set.hpp ./gecode/set/var/print.hpp ./gecode/set/var/set.hpp \
+	./gecode/set/view.hpp ./gecode/set/view/cached.hpp ./gecode/set/view/complement.hpp \
+	./gecode/set/view/const.hpp ./gecode/set/view/print.hpp ./gecode/set/view/set.hpp \
+	./gecode/set/view/singleton.hpp ./gecode/support.hh ./gecode/support/allocator.hpp \
+	./gecode/support/auto-link.hpp ./gecode/support/bitset-base.hpp ./gecode/support/bitset-offset.hpp \
+	./gecode/support/bitset.hpp ./gecode/support/block-allocator.hpp ./gecode/support/cast.hpp \
+	./gecode/support/config.hpp ./gecode/support/dynamic-array.hpp ./gecode/support/dynamic-queue.hpp \
+	./gecode/support/dynamic-stack.hpp ./gecode/support/exception.hpp ./gecode/support/hash.hpp \
+	./gecode/support/heap.hpp ./gecode/support/hw-rnd.hpp ./gecode/support/int-type.hpp \
+	./gecode/support/macros.hpp ./gecode/support/marked-pointer.hpp ./gecode/support/random.hpp \
+	./gecode/support/ref-count.hpp ./gecode/support/run-jobs.hpp ./gecode/support/sort.hpp \
+	./gecode/support/static-stack.hpp ./gecode/support/thread.hpp ./gecode/support/thread/thread.hpp \
+	./gecode/support/timer.hpp ./test/flatzinc.hh ./test/test.hh \
+	./test/test.hpp 
+test/flatzinc/cumulatives_full_2$(OBJSUFFIX) test/flatzinc/cumulatives_full_2$(SBJSUFFIX): \
+	./gecode/driver.hh ./gecode/driver/options.hpp ./gecode/driver/script.hpp \
+	./gecode/flatzinc.hh ./gecode/flatzinc/ast.hh ./gecode/flatzinc/conexpr.hh \
+	./gecode/flatzinc/option.hh ./gecode/flatzinc/varspec.hh ./gecode/float.hh \
+	./gecode/float/array-traits.hpp ./gecode/float/array.hpp ./gecode/float/branch.hpp \
+	./gecode/float/branch/action.hpp ./gecode/float/branch/afc.hpp ./gecode/float/branch/assign.hpp \
+	./gecode/float/branch/chb.hpp ./gecode/float/branch/traits.hpp ./gecode/float/branch/val.hpp \
+	./gecode/float/branch/var.hpp ./gecode/float/channel.hpp ./gecode/float/exception.hpp \
+	./gecode/float/limits.hpp ./gecode/float/nextafter.hpp ./gecode/float/num.hpp \
+	./gecode/float/rounding.hpp ./gecode/float/trace.hpp ./gecode/float/trace/delta.hpp \
+	./gecode/float/trace/trace-view.hpp ./gecode/float/trace/traits.hpp ./gecode/float/val.hpp \
+	./gecode/float/var-imp.hpp ./gecode/float/var-imp/delta.hpp ./gecode/float/var-imp/float.hpp \
+	./gecode/float/var/float.hpp ./gecode/float/var/print.hpp ./gecode/float/view.hpp \
+	./gecode/float/view/float.hpp ./gecode/float/view/minus.hpp ./gecode/float/view/offset.hpp \
+	./gecode/float/view/print.hpp ./gecode/float/view/rel-test.hpp ./gecode/float/view/scale.hpp \
+	./gecode/gist.hh ./gecode/gist/gist.hpp ./gecode/int.hh \
+	./gecode/int/array-traits.hpp ./gecode/int/array.hpp ./gecode/int/branch.hpp \
+	./gecode/int/branch/action.hpp ./gecode/int/branch/afc.hpp ./gecode/int/branch/assign.hpp \
+	./gecode/int/branch/chb.hpp ./gecode/int/branch/traits.hpp ./gecode/int/branch/val.hpp \
+	./gecode/int/branch/var.hpp ./gecode/int/channel.hpp ./gecode/int/div.hh \
+	./gecode/int/div.hpp ./gecode/int/exception.hpp ./gecode/int/extensional.hpp \
+	./gecode/int/extensional/dfa.hpp ./gecode/int/extensional/tuple-set.hpp ./gecode/int/int-set-1.hpp \
+	./gecode/int/int-set-2.hpp ./gecode/int/ipl.hpp ./gecode/int/irt.hpp \
+	./gecode/int/limits.hpp ./gecode/int/propagator.hpp ./gecode/int/reify.hpp \
+	./gecode/int/trace.hpp ./gecode/int/trace/bool-delta.hpp ./gecode/int/trace/bool-trace-view.hpp \
+	./gecode/int/trace/int-delta.hpp ./gecode/int/trace/int-trace-view.hpp ./gecode/int/trace/traits.hpp \
+	./gecode/int/var-imp.hpp ./gecode/int/var-imp/bool.hpp ./gecode/int/var-imp/delta.hpp \
+	./gecode/int/var-imp/int.hpp ./gecode/int/var/bool.hpp ./gecode/int/var/int.hpp \
+	./gecode/int/var/print.hpp ./gecode/int/view.hpp ./gecode/int/view/bool-test.hpp \
+	./gecode/int/view/bool.hpp ./gecode/int/view/cached.hpp ./gecode/int/view/constint.hpp \
+	./gecode/int/view/int.hpp ./gecode/int/view/iter.hpp ./gecode/int/view/minus.hpp \
+	./gecode/int/view/neg-bool.hpp ./gecode/int/view/offset.hpp ./gecode/int/view/print.hpp \
+	./gecode/int/view/rel-test.hpp ./gecode/int/view/scale.hpp ./gecode/int/view/zero.hpp \
+	./gecode/iter.hh ./gecode/iter/ranges-add.hpp ./gecode/iter/ranges-append.hpp \
+	./gecode/iter/ranges-array.hpp ./gecode/iter/ranges-cache.hpp ./gecode/iter/ranges-compl.hpp \
+	./gecode/iter/ranges-diff.hpp ./gecode/iter/ranges-empty.hpp ./gecode/iter/ranges-inter.hpp \
+	./gecode/iter/ranges-list.hpp ./gecode/iter/ranges-map.hpp ./gecode/iter/ranges-minmax.hpp \
+	./gecode/iter/ranges-minus.hpp ./gecode/iter/ranges-negative.hpp ./gecode/iter/ranges-offset.hpp \
+	./gecode/iter/ranges-operations.hpp ./gecode/iter/ranges-positive.hpp ./gecode/iter/ranges-rangelist.hpp \
+	./gecode/iter/ranges-scale.hpp ./gecode/iter/ranges-singleton-append.hpp ./gecode/iter/ranges-singleton.hpp \
+	./gecode/iter/ranges-size.hpp ./gecode/iter/ranges-union.hpp ./gecode/iter/ranges-values.hpp \
+	./gecode/iter/values-array.hpp ./gecode/iter/values-bitset.hpp ./gecode/iter/values-bitsetoffset.hpp \
+	./gecode/iter/values-inter.hpp ./gecode/iter/values-list.hpp ./gecode/iter/values-map.hpp \
+	./gecode/iter/values-minus.hpp ./gecode/iter/values-negative.hpp ./gecode/iter/values-offset.hpp \
+	./gecode/iter/values-positive.hpp ./gecode/iter/values-ranges.hpp ./gecode/iter/values-singleton.hpp \
+	./gecode/iter/values-union.hpp ./gecode/iter/values-unique.hpp ./gecode/kernel.hh \
+	./gecode/kernel/archive.hpp ./gecode/kernel/branch/action.hpp ./gecode/kernel/branch/afc.hpp \
+	./gecode/kernel/branch/chb.hpp ./gecode/kernel/branch/filter.hpp ./gecode/kernel/branch/merit.hpp \
+	./gecode/kernel/branch/print.hpp ./gecode/kernel/branch/tiebreak.hpp ./gecode/kernel/branch/traits.hpp \
+	./gecode/kernel/branch/val-commit.hpp ./gecode/kernel/branch/val-sel-commit.hpp ./gecode/kernel/branch/val-sel.hpp \
+	./gecode/kernel/branch/val.hpp ./gecode/kernel/branch/var.hpp ./gecode/kernel/branch/view-sel.hpp \
+	./gecode/kernel/branch/view-val.hpp ./gecode/kernel/branch/view.hpp ./gecode/kernel/core.hpp \
+	./gecode/kernel/data/array.hpp ./gecode/kernel/data/rnd.hpp ./gecode/kernel/data/shared-array.hpp \
+	./gecode/kernel/data/shared-data.hpp ./gecode/kernel/exception.hpp ./gecode/kernel/gpi.hpp \
+	./gecode/kernel/macros.hpp ./gecode/kernel/memory/allocators.hpp ./gecode/kernel/memory/config.hpp \
+	./gecode/kernel/memory/manager.hpp ./gecode/kernel/memory/region.hpp ./gecode/kernel/modevent.hpp \
+	./gecode/kernel/propagator/advisor.hpp ./gecode/kernel/propagator/pattern.hpp ./gecode/kernel/propagator/subscribed.hpp \
+	./gecode/kernel/propagator/wait.hpp ./gecode/kernel/range-list.hpp ./gecode/kernel/shared-object.hpp \
+	./gecode/kernel/shared-space-data.hpp ./gecode/kernel/trace/filter.hpp ./gecode/kernel/trace/general.hpp \
+	./gecode/kernel/trace/print.hpp ./gecode/kernel/trace/recorder.hpp ./gecode/kernel/trace/tracer.hpp \
+	./gecode/kernel/trace/traits.hpp ./gecode/kernel/var-imp.hpp ./gecode/kernel/var-type.hpp \
+	./gecode/kernel/var.hpp ./gecode/kernel/view.hpp ./gecode/minimodel.hh \
+	./gecode/minimodel/aliases.hpp ./gecode/minimodel/bool-expr.hpp ./gecode/minimodel/channel.hpp \
+	./gecode/minimodel/exception.hpp ./gecode/minimodel/float-expr.hpp ./gecode/minimodel/float-rel.hpp \
+	./gecode/minimodel/int-expr.hpp ./gecode/minimodel/int-rel.hpp ./gecode/minimodel/ipl.hpp \
+	./gecode/minimodel/ldsb.hpp ./gecode/minimodel/matrix.hpp ./gecode/minimodel/optimize.hpp \
+	./gecode/minimodel/reg.hpp ./gecode/minimodel/set-expr.hpp ./gecode/minimodel/set-rel.hpp \
+	./gecode/search.hh ./gecode/search/bab.hpp ./gecode/search/base.hpp \
+	./gecode/search/build.hpp ./gecode/search/cutoff.hpp ./gecode/search/dfs.hpp \
+	./gecode/search/engine.hpp ./gecode/search/exception.hpp ./gecode/search/lds.hpp \
+	./gecode/search/options.hpp ./gecode/search/pbs.hpp ./gecode/search/rbs.hpp \
+	./gecode/search/sebs.hpp ./gecode/search/seq/dead.hh ./gecode/search/statistics.hpp \
+	./gecode/search/stop.hpp ./gecode/search/support.hh ./gecode/search/trace-recorder.hpp \
+	./gecode/search/tracer.hpp ./gecode/search/traits.hpp ./gecode/set.hh \
+	./gecode/set/array-traits.hpp ./gecode/set/array.hpp ./gecode/set/branch.hpp \
+	./gecode/set/branch/action.hpp ./gecode/set/branch/afc.hpp ./gecode/set/branch/assign.hpp \
+	./gecode/set/branch/chb.hpp ./gecode/set/branch/traits.hpp ./gecode/set/branch/val.hpp \
+	./gecode/set/branch/var.hpp ./gecode/set/exception.hpp ./gecode/set/int.hpp \
+	./gecode/set/limits.hpp ./gecode/set/trace.hpp ./gecode/set/trace/delta.hpp \
+	./gecode/set/trace/trace-view.hpp ./gecode/set/trace/traits.hpp ./gecode/set/var-imp.hpp \
+	./gecode/set/var-imp/delta.hpp ./gecode/set/var-imp/integerset.hpp ./gecode/set/var-imp/iter.hpp \
+	./gecode/set/var-imp/set.hpp ./gecode/set/var/print.hpp ./gecode/set/var/set.hpp \
+	./gecode/set/view.hpp ./gecode/set/view/cached.hpp ./gecode/set/view/complement.hpp \
+	./gecode/set/view/const.hpp ./gecode/set/view/print.hpp ./gecode/set/view/set.hpp \
+	./gecode/set/view/singleton.hpp ./gecode/support.hh ./gecode/support/allocator.hpp \
+	./gecode/support/auto-link.hpp ./gecode/support/bitset-base.hpp ./gecode/support/bitset-offset.hpp \
+	./gecode/support/bitset.hpp ./gecode/support/block-allocator.hpp ./gecode/support/cast.hpp \
+	./gecode/support/config.hpp ./gecode/support/dynamic-array.hpp ./gecode/support/dynamic-queue.hpp \
+	./gecode/support/dynamic-stack.hpp ./gecode/support/exception.hpp ./gecode/support/hash.hpp \
+	./gecode/support/heap.hpp ./gecode/support/hw-rnd.hpp ./gecode/support/int-type.hpp \
+	./gecode/support/macros.hpp ./gecode/support/marked-pointer.hpp ./gecode/support/random.hpp \
+	./gecode/support/ref-count.hpp ./gecode/support/run-jobs.hpp ./gecode/support/sort.hpp \
+	./gecode/support/static-stack.hpp ./gecode/support/thread.hpp ./gecode/support/thread/thread.hpp \
+	./gecode/support/timer.hpp ./test/flatzinc.hh ./test/test.hh \
+	./test/test.hpp 
+test/flatzinc/cumulatives_full_3$(OBJSUFFIX) test/flatzinc/cumulatives_full_3$(SBJSUFFIX): \
+	./gecode/driver.hh ./gecode/driver/options.hpp ./gecode/driver/script.hpp \
+	./gecode/flatzinc.hh ./gecode/flatzinc/ast.hh ./gecode/flatzinc/conexpr.hh \
+	./gecode/flatzinc/option.hh ./gecode/flatzinc/varspec.hh ./gecode/float.hh \
+	./gecode/float/array-traits.hpp ./gecode/float/array.hpp ./gecode/float/branch.hpp \
+	./gecode/float/branch/action.hpp ./gecode/float/branch/afc.hpp ./gecode/float/branch/assign.hpp \
+	./gecode/float/branch/chb.hpp ./gecode/float/branch/traits.hpp ./gecode/float/branch/val.hpp \
+	./gecode/float/branch/var.hpp ./gecode/float/channel.hpp ./gecode/float/exception.hpp \
+	./gecode/float/limits.hpp ./gecode/float/nextafter.hpp ./gecode/float/num.hpp \
+	./gecode/float/rounding.hpp ./gecode/float/trace.hpp ./gecode/float/trace/delta.hpp \
+	./gecode/float/trace/trace-view.hpp ./gecode/float/trace/traits.hpp ./gecode/float/val.hpp \
+	./gecode/float/var-imp.hpp ./gecode/float/var-imp/delta.hpp ./gecode/float/var-imp/float.hpp \
+	./gecode/float/var/float.hpp ./gecode/float/var/print.hpp ./gecode/float/view.hpp \
+	./gecode/float/view/float.hpp ./gecode/float/view/minus.hpp ./gecode/float/view/offset.hpp \
+	./gecode/float/view/print.hpp ./gecode/float/view/rel-test.hpp ./gecode/float/view/scale.hpp \
+	./gecode/gist.hh ./gecode/gist/gist.hpp ./gecode/int.hh \
+	./gecode/int/array-traits.hpp ./gecode/int/array.hpp ./gecode/int/branch.hpp \
+	./gecode/int/branch/action.hpp ./gecode/int/branch/afc.hpp ./gecode/int/branch/assign.hpp \
+	./gecode/int/branch/chb.hpp ./gecode/int/branch/traits.hpp ./gecode/int/branch/val.hpp \
+	./gecode/int/branch/var.hpp ./gecode/int/channel.hpp ./gecode/int/div.hh \
+	./gecode/int/div.hpp ./gecode/int/exception.hpp ./gecode/int/extensional.hpp \
+	./gecode/int/extensional/dfa.hpp ./gecode/int/extensional/tuple-set.hpp ./gecode/int/int-set-1.hpp \
+	./gecode/int/int-set-2.hpp ./gecode/int/ipl.hpp ./gecode/int/irt.hpp \
+	./gecode/int/limits.hpp ./gecode/int/propagator.hpp ./gecode/int/reify.hpp \
+	./gecode/int/trace.hpp ./gecode/int/trace/bool-delta.hpp ./gecode/int/trace/bool-trace-view.hpp \
+	./gecode/int/trace/int-delta.hpp ./gecode/int/trace/int-trace-view.hpp ./gecode/int/trace/traits.hpp \
+	./gecode/int/var-imp.hpp ./gecode/int/var-imp/bool.hpp ./gecode/int/var-imp/delta.hpp \
+	./gecode/int/var-imp/int.hpp ./gecode/int/var/bool.hpp ./gecode/int/var/int.hpp \
+	./gecode/int/var/print.hpp ./gecode/int/view.hpp ./gecode/int/view/bool-test.hpp \
+	./gecode/int/view/bool.hpp ./gecode/int/view/cached.hpp ./gecode/int/view/constint.hpp \
+	./gecode/int/view/int.hpp ./gecode/int/view/iter.hpp ./gecode/int/view/minus.hpp \
+	./gecode/int/view/neg-bool.hpp ./gecode/int/view/offset.hpp ./gecode/int/view/print.hpp \
+	./gecode/int/view/rel-test.hpp ./gecode/int/view/scale.hpp ./gecode/int/view/zero.hpp \
+	./gecode/iter.hh ./gecode/iter/ranges-add.hpp ./gecode/iter/ranges-append.hpp \
+	./gecode/iter/ranges-array.hpp ./gecode/iter/ranges-cache.hpp ./gecode/iter/ranges-compl.hpp \
+	./gecode/iter/ranges-diff.hpp ./gecode/iter/ranges-empty.hpp ./gecode/iter/ranges-inter.hpp \
+	./gecode/iter/ranges-list.hpp ./gecode/iter/ranges-map.hpp ./gecode/iter/ranges-minmax.hpp \
+	./gecode/iter/ranges-minus.hpp ./gecode/iter/ranges-negative.hpp ./gecode/iter/ranges-offset.hpp \
+	./gecode/iter/ranges-operations.hpp ./gecode/iter/ranges-positive.hpp ./gecode/iter/ranges-rangelist.hpp \
+	./gecode/iter/ranges-scale.hpp ./gecode/iter/ranges-singleton-append.hpp ./gecode/iter/ranges-singleton.hpp \
+	./gecode/iter/ranges-size.hpp ./gecode/iter/ranges-union.hpp ./gecode/iter/ranges-values.hpp \
+	./gecode/iter/values-array.hpp ./gecode/iter/values-bitset.hpp ./gecode/iter/values-bitsetoffset.hpp \
+	./gecode/iter/values-inter.hpp ./gecode/iter/values-list.hpp ./gecode/iter/values-map.hpp \
+	./gecode/iter/values-minus.hpp ./gecode/iter/values-negative.hpp ./gecode/iter/values-offset.hpp \
+	./gecode/iter/values-positive.hpp ./gecode/iter/values-ranges.hpp ./gecode/iter/values-singleton.hpp \
+	./gecode/iter/values-union.hpp ./gecode/iter/values-unique.hpp ./gecode/kernel.hh \
+	./gecode/kernel/archive.hpp ./gecode/kernel/branch/action.hpp ./gecode/kernel/branch/afc.hpp \
+	./gecode/kernel/branch/chb.hpp ./gecode/kernel/branch/filter.hpp ./gecode/kernel/branch/merit.hpp \
+	./gecode/kernel/branch/print.hpp ./gecode/kernel/branch/tiebreak.hpp ./gecode/kernel/branch/traits.hpp \
+	./gecode/kernel/branch/val-commit.hpp ./gecode/kernel/branch/val-sel-commit.hpp ./gecode/kernel/branch/val-sel.hpp \
+	./gecode/kernel/branch/val.hpp ./gecode/kernel/branch/var.hpp ./gecode/kernel/branch/view-sel.hpp \
+	./gecode/kernel/branch/view-val.hpp ./gecode/kernel/branch/view.hpp ./gecode/kernel/core.hpp \
+	./gecode/kernel/data/array.hpp ./gecode/kernel/data/rnd.hpp ./gecode/kernel/data/shared-array.hpp \
+	./gecode/kernel/data/shared-data.hpp ./gecode/kernel/exception.hpp ./gecode/kernel/gpi.hpp \
+	./gecode/kernel/macros.hpp ./gecode/kernel/memory/allocators.hpp ./gecode/kernel/memory/config.hpp \
+	./gecode/kernel/memory/manager.hpp ./gecode/kernel/memory/region.hpp ./gecode/kernel/modevent.hpp \
+	./gecode/kernel/propagator/advisor.hpp ./gecode/kernel/propagator/pattern.hpp ./gecode/kernel/propagator/subscribed.hpp \
+	./gecode/kernel/propagator/wait.hpp ./gecode/kernel/range-list.hpp ./gecode/kernel/shared-object.hpp \
+	./gecode/kernel/shared-space-data.hpp ./gecode/kernel/trace/filter.hpp ./gecode/kernel/trace/general.hpp \
+	./gecode/kernel/trace/print.hpp ./gecode/kernel/trace/recorder.hpp ./gecode/kernel/trace/tracer.hpp \
+	./gecode/kernel/trace/traits.hpp ./gecode/kernel/var-imp.hpp ./gecode/kernel/var-type.hpp \
+	./gecode/kernel/var.hpp ./gecode/kernel/view.hpp ./gecode/minimodel.hh \
+	./gecode/minimodel/aliases.hpp ./gecode/minimodel/bool-expr.hpp ./gecode/minimodel/channel.hpp \
+	./gecode/minimodel/exception.hpp ./gecode/minimodel/float-expr.hpp ./gecode/minimodel/float-rel.hpp \
+	./gecode/minimodel/int-expr.hpp ./gecode/minimodel/int-rel.hpp ./gecode/minimodel/ipl.hpp \
+	./gecode/minimodel/ldsb.hpp ./gecode/minimodel/matrix.hpp ./gecode/minimodel/optimize.hpp \
+	./gecode/minimodel/reg.hpp ./gecode/minimodel/set-expr.hpp ./gecode/minimodel/set-rel.hpp \
+	./gecode/search.hh ./gecode/search/bab.hpp ./gecode/search/base.hpp \
+	./gecode/search/build.hpp ./gecode/search/cutoff.hpp ./gecode/search/dfs.hpp \
+	./gecode/search/engine.hpp ./gecode/search/exception.hpp ./gecode/search/lds.hpp \
+	./gecode/search/options.hpp ./gecode/search/pbs.hpp ./gecode/search/rbs.hpp \
+	./gecode/search/sebs.hpp ./gecode/search/seq/dead.hh ./gecode/search/statistics.hpp \
+	./gecode/search/stop.hpp ./gecode/search/support.hh ./gecode/search/trace-recorder.hpp \
+	./gecode/search/tracer.hpp ./gecode/search/traits.hpp ./gecode/set.hh \
+	./gecode/set/array-traits.hpp ./gecode/set/array.hpp ./gecode/set/branch.hpp \
+	./gecode/set/branch/action.hpp ./gecode/set/branch/afc.hpp ./gecode/set/branch/assign.hpp \
+	./gecode/set/branch/chb.hpp ./gecode/set/branch/traits.hpp ./gecode/set/branch/val.hpp \
+	./gecode/set/branch/var.hpp ./gecode/set/exception.hpp ./gecode/set/int.hpp \
+	./gecode/set/limits.hpp ./gecode/set/trace.hpp ./gecode/set/trace/delta.hpp \
+	./gecode/set/trace/trace-view.hpp ./gecode/set/trace/traits.hpp ./gecode/set/var-imp.hpp \
+	./gecode/set/var-imp/delta.hpp ./gecode/set/var-imp/integerset.hpp ./gecode/set/var-imp/iter.hpp \
+	./gecode/set/var-imp/set.hpp ./gecode/set/var/print.hpp ./gecode/set/var/set.hpp \
+	./gecode/set/view.hpp ./gecode/set/view/cached.hpp ./gecode/set/view/complement.hpp \
+	./gecode/set/view/const.hpp ./gecode/set/view/print.hpp ./gecode/set/view/set.hpp \
+	./gecode/set/view/singleton.hpp ./gecode/support.hh ./gecode/support/allocator.hpp \
+	./gecode/support/auto-link.hpp ./gecode/support/bitset-base.hpp ./gecode/support/bitset-offset.hpp \
+	./gecode/support/bitset.hpp ./gecode/support/block-allocator.hpp ./gecode/support/cast.hpp \
+	./gecode/support/config.hpp ./gecode/support/dynamic-array.hpp ./gecode/support/dynamic-queue.hpp \
+	./gecode/support/dynamic-stack.hpp ./gecode/support/exception.hpp ./gecode/support/hash.hpp \
+	./gecode/support/heap.hpp ./gecode/support/hw-rnd.hpp ./gecode/support/int-type.hpp \
+	./gecode/support/macros.hpp ./gecode/support/marked-pointer.hpp ./gecode/support/random.hpp \
+	./gecode/support/ref-count.hpp ./gecode/support/run-jobs.hpp ./gecode/support/sort.hpp \
+	./gecode/support/static-stack.hpp ./gecode/support/thread.hpp ./gecode/support/thread/thread.hpp \
+	./gecode/support/timer.hpp ./test/flatzinc.hh ./test/test.hh \
+	./test/test.hpp 
+test/flatzinc/cumulatives_full_4$(OBJSUFFIX) test/flatzinc/cumulatives_full_4$(SBJSUFFIX): \
+	./gecode/driver.hh ./gecode/driver/options.hpp ./gecode/driver/script.hpp \
+	./gecode/flatzinc.hh ./gecode/flatzinc/ast.hh ./gecode/flatzinc/conexpr.hh \
+	./gecode/flatzinc/option.hh ./gecode/flatzinc/varspec.hh ./gecode/float.hh \
+	./gecode/float/array-traits.hpp ./gecode/float/array.hpp ./gecode/float/branch.hpp \
+	./gecode/float/branch/action.hpp ./gecode/float/branch/afc.hpp ./gecode/float/branch/assign.hpp \
+	./gecode/float/branch/chb.hpp ./gecode/float/branch/traits.hpp ./gecode/float/branch/val.hpp \
+	./gecode/float/branch/var.hpp ./gecode/float/channel.hpp ./gecode/float/exception.hpp \
+	./gecode/float/limits.hpp ./gecode/float/nextafter.hpp ./gecode/float/num.hpp \
+	./gecode/float/rounding.hpp ./gecode/float/trace.hpp ./gecode/float/trace/delta.hpp \
+	./gecode/float/trace/trace-view.hpp ./gecode/float/trace/traits.hpp ./gecode/float/val.hpp \
+	./gecode/float/var-imp.hpp ./gecode/float/var-imp/delta.hpp ./gecode/float/var-imp/float.hpp \
+	./gecode/float/var/float.hpp ./gecode/float/var/print.hpp ./gecode/float/view.hpp \
+	./gecode/float/view/float.hpp ./gecode/float/view/minus.hpp ./gecode/float/view/offset.hpp \
+	./gecode/float/view/print.hpp ./gecode/float/view/rel-test.hpp ./gecode/float/view/scale.hpp \
+	./gecode/gist.hh ./gecode/gist/gist.hpp ./gecode/int.hh \
+	./gecode/int/array-traits.hpp ./gecode/int/array.hpp ./gecode/int/branch.hpp \
+	./gecode/int/branch/action.hpp ./gecode/int/branch/afc.hpp ./gecode/int/branch/assign.hpp \
+	./gecode/int/branch/chb.hpp ./gecode/int/branch/traits.hpp ./gecode/int/branch/val.hpp \
+	./gecode/int/branch/var.hpp ./gecode/int/channel.hpp ./gecode/int/div.hh \
+	./gecode/int/div.hpp ./gecode/int/exception.hpp ./gecode/int/extensional.hpp \
+	./gecode/int/extensional/dfa.hpp ./gecode/int/extensional/tuple-set.hpp ./gecode/int/int-set-1.hpp \
+	./gecode/int/int-set-2.hpp ./gecode/int/ipl.hpp ./gecode/int/irt.hpp \
+	./gecode/int/limits.hpp ./gecode/int/propagator.hpp ./gecode/int/reify.hpp \
+	./gecode/int/trace.hpp ./gecode/int/trace/bool-delta.hpp ./gecode/int/trace/bool-trace-view.hpp \
+	./gecode/int/trace/int-delta.hpp ./gecode/int/trace/int-trace-view.hpp ./gecode/int/trace/traits.hpp \
+	./gecode/int/var-imp.hpp ./gecode/int/var-imp/bool.hpp ./gecode/int/var-imp/delta.hpp \
+	./gecode/int/var-imp/int.hpp ./gecode/int/var/bool.hpp ./gecode/int/var/int.hpp \
+	./gecode/int/var/print.hpp ./gecode/int/view.hpp ./gecode/int/view/bool-test.hpp \
+	./gecode/int/view/bool.hpp ./gecode/int/view/cached.hpp ./gecode/int/view/constint.hpp \
+	./gecode/int/view/int.hpp ./gecode/int/view/iter.hpp ./gecode/int/view/minus.hpp \
+	./gecode/int/view/neg-bool.hpp ./gecode/int/view/offset.hpp ./gecode/int/view/print.hpp \
+	./gecode/int/view/rel-test.hpp ./gecode/int/view/scale.hpp ./gecode/int/view/zero.hpp \
+	./gecode/iter.hh ./gecode/iter/ranges-add.hpp ./gecode/iter/ranges-append.hpp \
+	./gecode/iter/ranges-array.hpp ./gecode/iter/ranges-cache.hpp ./gecode/iter/ranges-compl.hpp \
+	./gecode/iter/ranges-diff.hpp ./gecode/iter/ranges-empty.hpp ./gecode/iter/ranges-inter.hpp \
+	./gecode/iter/ranges-list.hpp ./gecode/iter/ranges-map.hpp ./gecode/iter/ranges-minmax.hpp \
+	./gecode/iter/ranges-minus.hpp ./gecode/iter/ranges-negative.hpp ./gecode/iter/ranges-offset.hpp \
+	./gecode/iter/ranges-operations.hpp ./gecode/iter/ranges-positive.hpp ./gecode/iter/ranges-rangelist.hpp \
+	./gecode/iter/ranges-scale.hpp ./gecode/iter/ranges-singleton-append.hpp ./gecode/iter/ranges-singleton.hpp \
+	./gecode/iter/ranges-size.hpp ./gecode/iter/ranges-union.hpp ./gecode/iter/ranges-values.hpp \
+	./gecode/iter/values-array.hpp ./gecode/iter/values-bitset.hpp ./gecode/iter/values-bitsetoffset.hpp \
+	./gecode/iter/values-inter.hpp ./gecode/iter/values-list.hpp ./gecode/iter/values-map.hpp \
+	./gecode/iter/values-minus.hpp ./gecode/iter/values-negative.hpp ./gecode/iter/values-offset.hpp \
+	./gecode/iter/values-positive.hpp ./gecode/iter/values-ranges.hpp ./gecode/iter/values-singleton.hpp \
+	./gecode/iter/values-union.hpp ./gecode/iter/values-unique.hpp ./gecode/kernel.hh \
+	./gecode/kernel/archive.hpp ./gecode/kernel/branch/action.hpp ./gecode/kernel/branch/afc.hpp \
+	./gecode/kernel/branch/chb.hpp ./gecode/kernel/branch/filter.hpp ./gecode/kernel/branch/merit.hpp \
+	./gecode/kernel/branch/print.hpp ./gecode/kernel/branch/tiebreak.hpp ./gecode/kernel/branch/traits.hpp \
+	./gecode/kernel/branch/val-commit.hpp ./gecode/kernel/branch/val-sel-commit.hpp ./gecode/kernel/branch/val-sel.hpp \
+	./gecode/kernel/branch/val.hpp ./gecode/kernel/branch/var.hpp ./gecode/kernel/branch/view-sel.hpp \
+	./gecode/kernel/branch/view-val.hpp ./gecode/kernel/branch/view.hpp ./gecode/kernel/core.hpp \
+	./gecode/kernel/data/array.hpp ./gecode/kernel/data/rnd.hpp ./gecode/kernel/data/shared-array.hpp \
+	./gecode/kernel/data/shared-data.hpp ./gecode/kernel/exception.hpp ./gecode/kernel/gpi.hpp \
+	./gecode/kernel/macros.hpp ./gecode/kernel/memory/allocators.hpp ./gecode/kernel/memory/config.hpp \
+	./gecode/kernel/memory/manager.hpp ./gecode/kernel/memory/region.hpp ./gecode/kernel/modevent.hpp \
+	./gecode/kernel/propagator/advisor.hpp ./gecode/kernel/propagator/pattern.hpp ./gecode/kernel/propagator/subscribed.hpp \
+	./gecode/kernel/propagator/wait.hpp ./gecode/kernel/range-list.hpp ./gecode/kernel/shared-object.hpp \
+	./gecode/kernel/shared-space-data.hpp ./gecode/kernel/trace/filter.hpp ./gecode/kernel/trace/general.hpp \
+	./gecode/kernel/trace/print.hpp ./gecode/kernel/trace/recorder.hpp ./gecode/kernel/trace/tracer.hpp \
+	./gecode/kernel/trace/traits.hpp ./gecode/kernel/var-imp.hpp ./gecode/kernel/var-type.hpp \
+	./gecode/kernel/var.hpp ./gecode/kernel/view.hpp ./gecode/minimodel.hh \
+	./gecode/minimodel/aliases.hpp ./gecode/minimodel/bool-expr.hpp ./gecode/minimodel/channel.hpp \
+	./gecode/minimodel/exception.hpp ./gecode/minimodel/float-expr.hpp ./gecode/minimodel/float-rel.hpp \
+	./gecode/minimodel/int-expr.hpp ./gecode/minimodel/int-rel.hpp ./gecode/minimodel/ipl.hpp \
+	./gecode/minimodel/ldsb.hpp ./gecode/minimodel/matrix.hpp ./gecode/minimodel/optimize.hpp \
+	./gecode/minimodel/reg.hpp ./gecode/minimodel/set-expr.hpp ./gecode/minimodel/set-rel.hpp \
+	./gecode/search.hh ./gecode/search/bab.hpp ./gecode/search/base.hpp \
+	./gecode/search/build.hpp ./gecode/search/cutoff.hpp ./gecode/search/dfs.hpp \
+	./gecode/search/engine.hpp ./gecode/search/exception.hpp ./gecode/search/lds.hpp \
+	./gecode/search/options.hpp ./gecode/search/pbs.hpp ./gecode/search/rbs.hpp \
+	./gecode/search/sebs.hpp ./gecode/search/seq/dead.hh ./gecode/search/statistics.hpp \
+	./gecode/search/stop.hpp ./gecode/search/support.hh ./gecode/search/trace-recorder.hpp \
+	./gecode/search/tracer.hpp ./gecode/search/traits.hpp ./gecode/set.hh \
+	./gecode/set/array-traits.hpp ./gecode/set/array.hpp ./gecode/set/branch.hpp \
+	./gecode/set/branch/action.hpp ./gecode/set/branch/afc.hpp ./gecode/set/branch/assign.hpp \
+	./gecode/set/branch/chb.hpp ./gecode/set/branch/traits.hpp ./gecode/set/branch/val.hpp \
+	./gecode/set/branch/var.hpp ./gecode/set/exception.hpp ./gecode/set/int.hpp \
+	./gecode/set/limits.hpp ./gecode/set/trace.hpp ./gecode/set/trace/delta.hpp \
+	./gecode/set/trace/trace-view.hpp ./gecode/set/trace/traits.hpp ./gecode/set/var-imp.hpp \
+	./gecode/set/var-imp/delta.hpp ./gecode/set/var-imp/integerset.hpp ./gecode/set/var-imp/iter.hpp \
+	./gecode/set/var-imp/set.hpp ./gecode/set/var/print.hpp ./gecode/set/var/set.hpp \
+	./gecode/set/view.hpp ./gecode/set/view/cached.hpp ./gecode/set/view/complement.hpp \
+	./gecode/set/view/const.hpp ./gecode/set/view/print.hpp ./gecode/set/view/set.hpp \
+	./gecode/set/view/singleton.hpp ./gecode/support.hh ./gecode/support/allocator.hpp \
+	./gecode/support/auto-link.hpp ./gecode/support/bitset-base.hpp ./gecode/support/bitset-offset.hpp \
+	./gecode/support/bitset.hpp ./gecode/support/block-allocator.hpp ./gecode/support/cast.hpp \
+	./gecode/support/config.hpp ./gecode/support/dynamic-array.hpp ./gecode/support/dynamic-queue.hpp \
+	./gecode/support/dynamic-stack.hpp ./gecode/support/exception.hpp ./gecode/support/hash.hpp \
+	./gecode/support/heap.hpp ./gecode/support/hw-rnd.hpp ./gecode/support/int-type.hpp \
+	./gecode/support/macros.hpp ./gecode/support/marked-pointer.hpp ./gecode/support/random.hpp \
+	./gecode/support/ref-count.hpp ./gecode/support/run-jobs.hpp ./gecode/support/sort.hpp \
+	./gecode/support/static-stack.hpp ./gecode/support/thread.hpp ./gecode/support/thread/thread.hpp \
+	./gecode/support/timer.hpp ./test/flatzinc.hh ./test/test.hh \
+	./test/test.hpp 
+test/flatzinc/cumulatives_full_5$(OBJSUFFIX) test/flatzinc/cumulatives_full_5$(SBJSUFFIX): \
+	./gecode/driver.hh ./gecode/driver/options.hpp ./gecode/driver/script.hpp \
+	./gecode/flatzinc.hh ./gecode/flatzinc/ast.hh ./gecode/flatzinc/conexpr.hh \
+	./gecode/flatzinc/option.hh ./gecode/flatzinc/varspec.hh ./gecode/float.hh \
+	./gecode/float/array-traits.hpp ./gecode/float/array.hpp ./gecode/float/branch.hpp \
+	./gecode/float/branch/action.hpp ./gecode/float/branch/afc.hpp ./gecode/float/branch/assign.hpp \
+	./gecode/float/branch/chb.hpp ./gecode/float/branch/traits.hpp ./gecode/float/branch/val.hpp \
+	./gecode/float/branch/var.hpp ./gecode/float/channel.hpp ./gecode/float/exception.hpp \
+	./gecode/float/limits.hpp ./gecode/float/nextafter.hpp ./gecode/float/num.hpp \
+	./gecode/float/rounding.hpp ./gecode/float/trace.hpp ./gecode/float/trace/delta.hpp \
+	./gecode/float/trace/trace-view.hpp ./gecode/float/trace/traits.hpp ./gecode/float/val.hpp \
+	./gecode/float/var-imp.hpp ./gecode/float/var-imp/delta.hpp ./gecode/float/var-imp/float.hpp \
+	./gecode/float/var/float.hpp ./gecode/float/var/print.hpp ./gecode/float/view.hpp \
+	./gecode/float/view/float.hpp ./gecode/float/view/minus.hpp ./gecode/float/view/offset.hpp \
+	./gecode/float/view/print.hpp ./gecode/float/view/rel-test.hpp ./gecode/float/view/scale.hpp \
+	./gecode/gist.hh ./gecode/gist/gist.hpp ./gecode/int.hh \
+	./gecode/int/array-traits.hpp ./gecode/int/array.hpp ./gecode/int/branch.hpp \
+	./gecode/int/branch/action.hpp ./gecode/int/branch/afc.hpp ./gecode/int/branch/assign.hpp \
+	./gecode/int/branch/chb.hpp ./gecode/int/branch/traits.hpp ./gecode/int/branch/val.hpp \
+	./gecode/int/branch/var.hpp ./gecode/int/channel.hpp ./gecode/int/div.hh \
+	./gecode/int/div.hpp ./gecode/int/exception.hpp ./gecode/int/extensional.hpp \
+	./gecode/int/extensional/dfa.hpp ./gecode/int/extensional/tuple-set.hpp ./gecode/int/int-set-1.hpp \
+	./gecode/int/int-set-2.hpp ./gecode/int/ipl.hpp ./gecode/int/irt.hpp \
+	./gecode/int/limits.hpp ./gecode/int/propagator.hpp ./gecode/int/reify.hpp \
+	./gecode/int/trace.hpp ./gecode/int/trace/bool-delta.hpp ./gecode/int/trace/bool-trace-view.hpp \
+	./gecode/int/trace/int-delta.hpp ./gecode/int/trace/int-trace-view.hpp ./gecode/int/trace/traits.hpp \
+	./gecode/int/var-imp.hpp ./gecode/int/var-imp/bool.hpp ./gecode/int/var-imp/delta.hpp \
+	./gecode/int/var-imp/int.hpp ./gecode/int/var/bool.hpp ./gecode/int/var/int.hpp \
+	./gecode/int/var/print.hpp ./gecode/int/view.hpp ./gecode/int/view/bool-test.hpp \
+	./gecode/int/view/bool.hpp ./gecode/int/view/cached.hpp ./gecode/int/view/constint.hpp \
+	./gecode/int/view/int.hpp ./gecode/int/view/iter.hpp ./gecode/int/view/minus.hpp \
+	./gecode/int/view/neg-bool.hpp ./gecode/int/view/offset.hpp ./gecode/int/view/print.hpp \
+	./gecode/int/view/rel-test.hpp ./gecode/int/view/scale.hpp ./gecode/int/view/zero.hpp \
+	./gecode/iter.hh ./gecode/iter/ranges-add.hpp ./gecode/iter/ranges-append.hpp \
+	./gecode/iter/ranges-array.hpp ./gecode/iter/ranges-cache.hpp ./gecode/iter/ranges-compl.hpp \
+	./gecode/iter/ranges-diff.hpp ./gecode/iter/ranges-empty.hpp ./gecode/iter/ranges-inter.hpp \
+	./gecode/iter/ranges-list.hpp ./gecode/iter/ranges-map.hpp ./gecode/iter/ranges-minmax.hpp \
+	./gecode/iter/ranges-minus.hpp ./gecode/iter/ranges-negative.hpp ./gecode/iter/ranges-offset.hpp \
+	./gecode/iter/ranges-operations.hpp ./gecode/iter/ranges-positive.hpp ./gecode/iter/ranges-rangelist.hpp \
+	./gecode/iter/ranges-scale.hpp ./gecode/iter/ranges-singleton-append.hpp ./gecode/iter/ranges-singleton.hpp \
+	./gecode/iter/ranges-size.hpp ./gecode/iter/ranges-union.hpp ./gecode/iter/ranges-values.hpp \
+	./gecode/iter/values-array.hpp ./gecode/iter/values-bitset.hpp ./gecode/iter/values-bitsetoffset.hpp \
+	./gecode/iter/values-inter.hpp ./gecode/iter/values-list.hpp ./gecode/iter/values-map.hpp \
+	./gecode/iter/values-minus.hpp ./gecode/iter/values-negative.hpp ./gecode/iter/values-offset.hpp \
+	./gecode/iter/values-positive.hpp ./gecode/iter/values-ranges.hpp ./gecode/iter/values-singleton.hpp \
+	./gecode/iter/values-union.hpp ./gecode/iter/values-unique.hpp ./gecode/kernel.hh \
+	./gecode/kernel/archive.hpp ./gecode/kernel/branch/action.hpp ./gecode/kernel/branch/afc.hpp \
+	./gecode/kernel/branch/chb.hpp ./gecode/kernel/branch/filter.hpp ./gecode/kernel/branch/merit.hpp \
+	./gecode/kernel/branch/print.hpp ./gecode/kernel/branch/tiebreak.hpp ./gecode/kernel/branch/traits.hpp \
+	./gecode/kernel/branch/val-commit.hpp ./gecode/kernel/branch/val-sel-commit.hpp ./gecode/kernel/branch/val-sel.hpp \
+	./gecode/kernel/branch/val.hpp ./gecode/kernel/branch/var.hpp ./gecode/kernel/branch/view-sel.hpp \
+	./gecode/kernel/branch/view-val.hpp ./gecode/kernel/branch/view.hpp ./gecode/kernel/core.hpp \
+	./gecode/kernel/data/array.hpp ./gecode/kernel/data/rnd.hpp ./gecode/kernel/data/shared-array.hpp \
+	./gecode/kernel/data/shared-data.hpp ./gecode/kernel/exception.hpp ./gecode/kernel/gpi.hpp \
+	./gecode/kernel/macros.hpp ./gecode/kernel/memory/allocators.hpp ./gecode/kernel/memory/config.hpp \
+	./gecode/kernel/memory/manager.hpp ./gecode/kernel/memory/region.hpp ./gecode/kernel/modevent.hpp \
+	./gecode/kernel/propagator/advisor.hpp ./gecode/kernel/propagator/pattern.hpp ./gecode/kernel/propagator/subscribed.hpp \
+	./gecode/kernel/propagator/wait.hpp ./gecode/kernel/range-list.hpp ./gecode/kernel/shared-object.hpp \
+	./gecode/kernel/shared-space-data.hpp ./gecode/kernel/trace/filter.hpp ./gecode/kernel/trace/general.hpp \
+	./gecode/kernel/trace/print.hpp ./gecode/kernel/trace/recorder.hpp ./gecode/kernel/trace/tracer.hpp \
+	./gecode/kernel/trace/traits.hpp ./gecode/kernel/var-imp.hpp ./gecode/kernel/var-type.hpp \
+	./gecode/kernel/var.hpp ./gecode/kernel/view.hpp ./gecode/minimodel.hh \
+	./gecode/minimodel/aliases.hpp ./gecode/minimodel/bool-expr.hpp ./gecode/minimodel/channel.hpp \
+	./gecode/minimodel/exception.hpp ./gecode/minimodel/float-expr.hpp ./gecode/minimodel/float-rel.hpp \
+	./gecode/minimodel/int-expr.hpp ./gecode/minimodel/int-rel.hpp ./gecode/minimodel/ipl.hpp \
+	./gecode/minimodel/ldsb.hpp ./gecode/minimodel/matrix.hpp ./gecode/minimodel/optimize.hpp \
+	./gecode/minimodel/reg.hpp ./gecode/minimodel/set-expr.hpp ./gecode/minimodel/set-rel.hpp \
+	./gecode/search.hh ./gecode/search/bab.hpp ./gecode/search/base.hpp \
+	./gecode/search/build.hpp ./gecode/search/cutoff.hpp ./gecode/search/dfs.hpp \
+	./gecode/search/engine.hpp ./gecode/search/exception.hpp ./gecode/search/lds.hpp \
+	./gecode/search/options.hpp ./gecode/search/pbs.hpp ./gecode/search/rbs.hpp \
+	./gecode/search/sebs.hpp ./gecode/search/seq/dead.hh ./gecode/search/statistics.hpp \
+	./gecode/search/stop.hpp ./gecode/search/support.hh ./gecode/search/trace-recorder.hpp \
+	./gecode/search/tracer.hpp ./gecode/search/traits.hpp ./gecode/set.hh \
+	./gecode/set/array-traits.hpp ./gecode/set/array.hpp ./gecode/set/branch.hpp \
+	./gecode/set/branch/action.hpp ./gecode/set/branch/afc.hpp ./gecode/set/branch/assign.hpp \
+	./gecode/set/branch/chb.hpp ./gecode/set/branch/traits.hpp ./gecode/set/branch/val.hpp \
+	./gecode/set/branch/var.hpp ./gecode/set/exception.hpp ./gecode/set/int.hpp \
+	./gecode/set/limits.hpp ./gecode/set/trace.hpp ./gecode/set/trace/delta.hpp \
+	./gecode/set/trace/trace-view.hpp ./gecode/set/trace/traits.hpp ./gecode/set/var-imp.hpp \
+	./gecode/set/var-imp/delta.hpp ./gecode/set/var-imp/integerset.hpp ./gecode/set/var-imp/iter.hpp \
+	./gecode/set/var-imp/set.hpp ./gecode/set/var/print.hpp ./gecode/set/var/set.hpp \
+	./gecode/set/view.hpp ./gecode/set/view/cached.hpp ./gecode/set/view/complement.hpp \
+	./gecode/set/view/const.hpp ./gecode/set/view/print.hpp ./gecode/set/view/set.hpp \
+	./gecode/set/view/singleton.hpp ./gecode/support.hh ./gecode/support/allocator.hpp \
+	./gecode/support/auto-link.hpp ./gecode/support/bitset-base.hpp ./gecode/support/bitset-offset.hpp \
+	./gecode/support/bitset.hpp ./gecode/support/block-allocator.hpp ./gecode/support/cast.hpp \
+	./gecode/support/config.hpp ./gecode/support/dynamic-array.hpp ./gecode/support/dynamic-queue.hpp \
+	./gecode/support/dynamic-stack.hpp ./gecode/support/exception.hpp ./gecode/support/hash.hpp \
+	./gecode/support/heap.hpp ./gecode/support/hw-rnd.hpp ./gecode/support/int-type.hpp \
+	./gecode/support/macros.hpp ./gecode/support/marked-pointer.hpp ./gecode/support/random.hpp \
+	./gecode/support/ref-count.hpp ./gecode/support/run-jobs.hpp ./gecode/support/sort.hpp \
+	./gecode/support/static-stack.hpp ./gecode/support/thread.hpp ./gecode/support/thread/thread.hpp \
+	./gecode/support/timer.hpp ./test/flatzinc.hh ./test/test.hh \
+	./test/test.hpp 
+test/flatzinc/cumulatives_full_6$(OBJSUFFIX) test/flatzinc/cumulatives_full_6$(SBJSUFFIX): \
+	./gecode/driver.hh ./gecode/driver/options.hpp ./gecode/driver/script.hpp \
+	./gecode/flatzinc.hh ./gecode/flatzinc/ast.hh ./gecode/flatzinc/conexpr.hh \
+	./gecode/flatzinc/option.hh ./gecode/flatzinc/varspec.hh ./gecode/float.hh \
+	./gecode/float/array-traits.hpp ./gecode/float/array.hpp ./gecode/float/branch.hpp \
+	./gecode/float/branch/action.hpp ./gecode/float/branch/afc.hpp ./gecode/float/branch/assign.hpp \
+	./gecode/float/branch/chb.hpp ./gecode/float/branch/traits.hpp ./gecode/float/branch/val.hpp \
+	./gecode/float/branch/var.hpp ./gecode/float/channel.hpp ./gecode/float/exception.hpp \
+	./gecode/float/limits.hpp ./gecode/float/nextafter.hpp ./gecode/float/num.hpp \
+	./gecode/float/rounding.hpp ./gecode/float/trace.hpp ./gecode/float/trace/delta.hpp \
+	./gecode/float/trace/trace-view.hpp ./gecode/float/trace/traits.hpp ./gecode/float/val.hpp \
+	./gecode/float/var-imp.hpp ./gecode/float/var-imp/delta.hpp ./gecode/float/var-imp/float.hpp \
+	./gecode/float/var/float.hpp ./gecode/float/var/print.hpp ./gecode/float/view.hpp \
+	./gecode/float/view/float.hpp ./gecode/float/view/minus.hpp ./gecode/float/view/offset.hpp \
+	./gecode/float/view/print.hpp ./gecode/float/view/rel-test.hpp ./gecode/float/view/scale.hpp \
+	./gecode/gist.hh ./gecode/gist/gist.hpp ./gecode/int.hh \
+	./gecode/int/array-traits.hpp ./gecode/int/array.hpp ./gecode/int/branch.hpp \
+	./gecode/int/branch/action.hpp ./gecode/int/branch/afc.hpp ./gecode/int/branch/assign.hpp \
+	./gecode/int/branch/chb.hpp ./gecode/int/branch/traits.hpp ./gecode/int/branch/val.hpp \
+	./gecode/int/branch/var.hpp ./gecode/int/channel.hpp ./gecode/int/div.hh \
+	./gecode/int/div.hpp ./gecode/int/exception.hpp ./gecode/int/extensional.hpp \
+	./gecode/int/extensional/dfa.hpp ./gecode/int/extensional/tuple-set.hpp ./gecode/int/int-set-1.hpp \
+	./gecode/int/int-set-2.hpp ./gecode/int/ipl.hpp ./gecode/int/irt.hpp \
+	./gecode/int/limits.hpp ./gecode/int/propagator.hpp ./gecode/int/reify.hpp \
+	./gecode/int/trace.hpp ./gecode/int/trace/bool-delta.hpp ./gecode/int/trace/bool-trace-view.hpp \
+	./gecode/int/trace/int-delta.hpp ./gecode/int/trace/int-trace-view.hpp ./gecode/int/trace/traits.hpp \
+	./gecode/int/var-imp.hpp ./gecode/int/var-imp/bool.hpp ./gecode/int/var-imp/delta.hpp \
+	./gecode/int/var-imp/int.hpp ./gecode/int/var/bool.hpp ./gecode/int/var/int.hpp \
+	./gecode/int/var/print.hpp ./gecode/int/view.hpp ./gecode/int/view/bool-test.hpp \
+	./gecode/int/view/bool.hpp ./gecode/int/view/cached.hpp ./gecode/int/view/constint.hpp \
+	./gecode/int/view/int.hpp ./gecode/int/view/iter.hpp ./gecode/int/view/minus.hpp \
+	./gecode/int/view/neg-bool.hpp ./gecode/int/view/offset.hpp ./gecode/int/view/print.hpp \
+	./gecode/int/view/rel-test.hpp ./gecode/int/view/scale.hpp ./gecode/int/view/zero.hpp \
+	./gecode/iter.hh ./gecode/iter/ranges-add.hpp ./gecode/iter/ranges-append.hpp \
+	./gecode/iter/ranges-array.hpp ./gecode/iter/ranges-cache.hpp ./gecode/iter/ranges-compl.hpp \
+	./gecode/iter/ranges-diff.hpp ./gecode/iter/ranges-empty.hpp ./gecode/iter/ranges-inter.hpp \
+	./gecode/iter/ranges-list.hpp ./gecode/iter/ranges-map.hpp ./gecode/iter/ranges-minmax.hpp \
+	./gecode/iter/ranges-minus.hpp ./gecode/iter/ranges-negative.hpp ./gecode/iter/ranges-offset.hpp \
+	./gecode/iter/ranges-operations.hpp ./gecode/iter/ranges-positive.hpp ./gecode/iter/ranges-rangelist.hpp \
+	./gecode/iter/ranges-scale.hpp ./gecode/iter/ranges-singleton-append.hpp ./gecode/iter/ranges-singleton.hpp \
+	./gecode/iter/ranges-size.hpp ./gecode/iter/ranges-union.hpp ./gecode/iter/ranges-values.hpp \
+	./gecode/iter/values-array.hpp ./gecode/iter/values-bitset.hpp ./gecode/iter/values-bitsetoffset.hpp \
+	./gecode/iter/values-inter.hpp ./gecode/iter/values-list.hpp ./gecode/iter/values-map.hpp \
+	./gecode/iter/values-minus.hpp ./gecode/iter/values-negative.hpp ./gecode/iter/values-offset.hpp \
+	./gecode/iter/values-positive.hpp ./gecode/iter/values-ranges.hpp ./gecode/iter/values-singleton.hpp \
+	./gecode/iter/values-union.hpp ./gecode/iter/values-unique.hpp ./gecode/kernel.hh \
+	./gecode/kernel/archive.hpp ./gecode/kernel/branch/action.hpp ./gecode/kernel/branch/afc.hpp \
+	./gecode/kernel/branch/chb.hpp ./gecode/kernel/branch/filter.hpp ./gecode/kernel/branch/merit.hpp \
+	./gecode/kernel/branch/print.hpp ./gecode/kernel/branch/tiebreak.hpp ./gecode/kernel/branch/traits.hpp \
+	./gecode/kernel/branch/val-commit.hpp ./gecode/kernel/branch/val-sel-commit.hpp ./gecode/kernel/branch/val-sel.hpp \
+	./gecode/kernel/branch/val.hpp ./gecode/kernel/branch/var.hpp ./gecode/kernel/branch/view-sel.hpp \
+	./gecode/kernel/branch/view-val.hpp ./gecode/kernel/branch/view.hpp ./gecode/kernel/core.hpp \
+	./gecode/kernel/data/array.hpp ./gecode/kernel/data/rnd.hpp ./gecode/kernel/data/shared-array.hpp \
+	./gecode/kernel/data/shared-data.hpp ./gecode/kernel/exception.hpp ./gecode/kernel/gpi.hpp \
+	./gecode/kernel/macros.hpp ./gecode/kernel/memory/allocators.hpp ./gecode/kernel/memory/config.hpp \
+	./gecode/kernel/memory/manager.hpp ./gecode/kernel/memory/region.hpp ./gecode/kernel/modevent.hpp \
+	./gecode/kernel/propagator/advisor.hpp ./gecode/kernel/propagator/pattern.hpp ./gecode/kernel/propagator/subscribed.hpp \
+	./gecode/kernel/propagator/wait.hpp ./gecode/kernel/range-list.hpp ./gecode/kernel/shared-object.hpp \
+	./gecode/kernel/shared-space-data.hpp ./gecode/kernel/trace/filter.hpp ./gecode/kernel/trace/general.hpp \
+	./gecode/kernel/trace/print.hpp ./gecode/kernel/trace/recorder.hpp ./gecode/kernel/trace/tracer.hpp \
+	./gecode/kernel/trace/traits.hpp ./gecode/kernel/var-imp.hpp ./gecode/kernel/var-type.hpp \
+	./gecode/kernel/var.hpp ./gecode/kernel/view.hpp ./gecode/minimodel.hh \
+	./gecode/minimodel/aliases.hpp ./gecode/minimodel/bool-expr.hpp ./gecode/minimodel/channel.hpp \
+	./gecode/minimodel/exception.hpp ./gecode/minimodel/float-expr.hpp ./gecode/minimodel/float-rel.hpp \
+	./gecode/minimodel/int-expr.hpp ./gecode/minimodel/int-rel.hpp ./gecode/minimodel/ipl.hpp \
+	./gecode/minimodel/ldsb.hpp ./gecode/minimodel/matrix.hpp ./gecode/minimodel/optimize.hpp \
+	./gecode/minimodel/reg.hpp ./gecode/minimodel/set-expr.hpp ./gecode/minimodel/set-rel.hpp \
+	./gecode/search.hh ./gecode/search/bab.hpp ./gecode/search/base.hpp \
+	./gecode/search/build.hpp ./gecode/search/cutoff.hpp ./gecode/search/dfs.hpp \
+	./gecode/search/engine.hpp ./gecode/search/exception.hpp ./gecode/search/lds.hpp \
+	./gecode/search/options.hpp ./gecode/search/pbs.hpp ./gecode/search/rbs.hpp \
+	./gecode/search/sebs.hpp ./gecode/search/seq/dead.hh ./gecode/search/statistics.hpp \
+	./gecode/search/stop.hpp ./gecode/search/support.hh ./gecode/search/trace-recorder.hpp \
+	./gecode/search/tracer.hpp ./gecode/search/traits.hpp ./gecode/set.hh \
+	./gecode/set/array-traits.hpp ./gecode/set/array.hpp ./gecode/set/branch.hpp \
+	./gecode/set/branch/action.hpp ./gecode/set/branch/afc.hpp ./gecode/set/branch/assign.hpp \
+	./gecode/set/branch/chb.hpp ./gecode/set/branch/traits.hpp ./gecode/set/branch/val.hpp \
+	./gecode/set/branch/var.hpp ./gecode/set/exception.hpp ./gecode/set/int.hpp \
+	./gecode/set/limits.hpp ./gecode/set/trace.hpp ./gecode/set/trace/delta.hpp \
+	./gecode/set/trace/trace-view.hpp ./gecode/set/trace/traits.hpp ./gecode/set/var-imp.hpp \
+	./gecode/set/var-imp/delta.hpp ./gecode/set/var-imp/integerset.hpp ./gecode/set/var-imp/iter.hpp \
+	./gecode/set/var-imp/set.hpp ./gecode/set/var/print.hpp ./gecode/set/var/set.hpp \
+	./gecode/set/view.hpp ./gecode/set/view/cached.hpp ./gecode/set/view/complement.hpp \
+	./gecode/set/view/const.hpp ./gecode/set/view/print.hpp ./gecode/set/view/set.hpp \
+	./gecode/set/view/singleton.hpp ./gecode/support.hh ./gecode/support/allocator.hpp \
+	./gecode/support/auto-link.hpp ./gecode/support/bitset-base.hpp ./gecode/support/bitset-offset.hpp \
+	./gecode/support/bitset.hpp ./gecode/support/block-allocator.hpp ./gecode/support/cast.hpp \
+	./gecode/support/config.hpp ./gecode/support/dynamic-array.hpp ./gecode/support/dynamic-queue.hpp \
+	./gecode/support/dynamic-stack.hpp ./gecode/support/exception.hpp ./gecode/support/hash.hpp \
+	./gecode/support/heap.hpp ./gecode/support/hw-rnd.hpp ./gecode/support/int-type.hpp \
+	./gecode/support/macros.hpp ./gecode/support/marked-pointer.hpp ./gecode/support/random.hpp \
+	./gecode/support/ref-count.hpp ./gecode/support/run-jobs.hpp ./gecode/support/sort.hpp \
+	./gecode/support/static-stack.hpp ./gecode/support/thread.hpp ./gecode/support/thread/thread.hpp \
+	./gecode/support/timer.hpp ./test/flatzinc.hh ./test/test.hh \
+	./test/test.hpp 
+test/flatzinc/cumulatives_full_7$(OBJSUFFIX) test/flatzinc/cumulatives_full_7$(SBJSUFFIX): \
+	./gecode/driver.hh ./gecode/driver/options.hpp ./gecode/driver/script.hpp \
+	./gecode/flatzinc.hh ./gecode/flatzinc/ast.hh ./gecode/flatzinc/conexpr.hh \
+	./gecode/flatzinc/option.hh ./gecode/flatzinc/varspec.hh ./gecode/float.hh \
+	./gecode/float/array-traits.hpp ./gecode/float/array.hpp ./gecode/float/branch.hpp \
+	./gecode/float/branch/action.hpp ./gecode/float/branch/afc.hpp ./gecode/float/branch/assign.hpp \
+	./gecode/float/branch/chb.hpp ./gecode/float/branch/traits.hpp ./gecode/float/branch/val.hpp \
+	./gecode/float/branch/var.hpp ./gecode/float/channel.hpp ./gecode/float/exception.hpp \
+	./gecode/float/limits.hpp ./gecode/float/nextafter.hpp ./gecode/float/num.hpp \
+	./gecode/float/rounding.hpp ./gecode/float/trace.hpp ./gecode/float/trace/delta.hpp \
+	./gecode/float/trace/trace-view.hpp ./gecode/float/trace/traits.hpp ./gecode/float/val.hpp \
+	./gecode/float/var-imp.hpp ./gecode/float/var-imp/delta.hpp ./gecode/float/var-imp/float.hpp \
+	./gecode/float/var/float.hpp ./gecode/float/var/print.hpp ./gecode/float/view.hpp \
+	./gecode/float/view/float.hpp ./gecode/float/view/minus.hpp ./gecode/float/view/offset.hpp \
+	./gecode/float/view/print.hpp ./gecode/float/view/rel-test.hpp ./gecode/float/view/scale.hpp \
+	./gecode/gist.hh ./gecode/gist/gist.hpp ./gecode/int.hh \
+	./gecode/int/array-traits.hpp ./gecode/int/array.hpp ./gecode/int/branch.hpp \
+	./gecode/int/branch/action.hpp ./gecode/int/branch/afc.hpp ./gecode/int/branch/assign.hpp \
+	./gecode/int/branch/chb.hpp ./gecode/int/branch/traits.hpp ./gecode/int/branch/val.hpp \
+	./gecode/int/branch/var.hpp ./gecode/int/channel.hpp ./gecode/int/div.hh \
+	./gecode/int/div.hpp ./gecode/int/exception.hpp ./gecode/int/extensional.hpp \
+	./gecode/int/extensional/dfa.hpp ./gecode/int/extensional/tuple-set.hpp ./gecode/int/int-set-1.hpp \
+	./gecode/int/int-set-2.hpp ./gecode/int/ipl.hpp ./gecode/int/irt.hpp \
+	./gecode/int/limits.hpp ./gecode/int/propagator.hpp ./gecode/int/reify.hpp \
+	./gecode/int/trace.hpp ./gecode/int/trace/bool-delta.hpp ./gecode/int/trace/bool-trace-view.hpp \
+	./gecode/int/trace/int-delta.hpp ./gecode/int/trace/int-trace-view.hpp ./gecode/int/trace/traits.hpp \
+	./gecode/int/var-imp.hpp ./gecode/int/var-imp/bool.hpp ./gecode/int/var-imp/delta.hpp \
+	./gecode/int/var-imp/int.hpp ./gecode/int/var/bool.hpp ./gecode/int/var/int.hpp \
+	./gecode/int/var/print.hpp ./gecode/int/view.hpp ./gecode/int/view/bool-test.hpp \
+	./gecode/int/view/bool.hpp ./gecode/int/view/cached.hpp ./gecode/int/view/constint.hpp \
+	./gecode/int/view/int.hpp ./gecode/int/view/iter.hpp ./gecode/int/view/minus.hpp \
+	./gecode/int/view/neg-bool.hpp ./gecode/int/view/offset.hpp ./gecode/int/view/print.hpp \
+	./gecode/int/view/rel-test.hpp ./gecode/int/view/scale.hpp ./gecode/int/view/zero.hpp \
+	./gecode/iter.hh ./gecode/iter/ranges-add.hpp ./gecode/iter/ranges-append.hpp \
+	./gecode/iter/ranges-array.hpp ./gecode/iter/ranges-cache.hpp ./gecode/iter/ranges-compl.hpp \
+	./gecode/iter/ranges-diff.hpp ./gecode/iter/ranges-empty.hpp ./gecode/iter/ranges-inter.hpp \
+	./gecode/iter/ranges-list.hpp ./gecode/iter/ranges-map.hpp ./gecode/iter/ranges-minmax.hpp \
+	./gecode/iter/ranges-minus.hpp ./gecode/iter/ranges-negative.hpp ./gecode/iter/ranges-offset.hpp \
+	./gecode/iter/ranges-operations.hpp ./gecode/iter/ranges-positive.hpp ./gecode/iter/ranges-rangelist.hpp \
+	./gecode/iter/ranges-scale.hpp ./gecode/iter/ranges-singleton-append.hpp ./gecode/iter/ranges-singleton.hpp \
+	./gecode/iter/ranges-size.hpp ./gecode/iter/ranges-union.hpp ./gecode/iter/ranges-values.hpp \
+	./gecode/iter/values-array.hpp ./gecode/iter/values-bitset.hpp ./gecode/iter/values-bitsetoffset.hpp \
+	./gecode/iter/values-inter.hpp ./gecode/iter/values-list.hpp ./gecode/iter/values-map.hpp \
+	./gecode/iter/values-minus.hpp ./gecode/iter/values-negative.hpp ./gecode/iter/values-offset.hpp \
+	./gecode/iter/values-positive.hpp ./gecode/iter/values-ranges.hpp ./gecode/iter/values-singleton.hpp \
+	./gecode/iter/values-union.hpp ./gecode/iter/values-unique.hpp ./gecode/kernel.hh \
+	./gecode/kernel/archive.hpp ./gecode/kernel/branch/action.hpp ./gecode/kernel/branch/afc.hpp \
+	./gecode/kernel/branch/chb.hpp ./gecode/kernel/branch/filter.hpp ./gecode/kernel/branch/merit.hpp \
+	./gecode/kernel/branch/print.hpp ./gecode/kernel/branch/tiebreak.hpp ./gecode/kernel/branch/traits.hpp \
+	./gecode/kernel/branch/val-commit.hpp ./gecode/kernel/branch/val-sel-commit.hpp ./gecode/kernel/branch/val-sel.hpp \
+	./gecode/kernel/branch/val.hpp ./gecode/kernel/branch/var.hpp ./gecode/kernel/branch/view-sel.hpp \
+	./gecode/kernel/branch/view-val.hpp ./gecode/kernel/branch/view.hpp ./gecode/kernel/core.hpp \
+	./gecode/kernel/data/array.hpp ./gecode/kernel/data/rnd.hpp ./gecode/kernel/data/shared-array.hpp \
+	./gecode/kernel/data/shared-data.hpp ./gecode/kernel/exception.hpp ./gecode/kernel/gpi.hpp \
+	./gecode/kernel/macros.hpp ./gecode/kernel/memory/allocators.hpp ./gecode/kernel/memory/config.hpp \
+	./gecode/kernel/memory/manager.hpp ./gecode/kernel/memory/region.hpp ./gecode/kernel/modevent.hpp \
+	./gecode/kernel/propagator/advisor.hpp ./gecode/kernel/propagator/pattern.hpp ./gecode/kernel/propagator/subscribed.hpp \
+	./gecode/kernel/propagator/wait.hpp ./gecode/kernel/range-list.hpp ./gecode/kernel/shared-object.hpp \
+	./gecode/kernel/shared-space-data.hpp ./gecode/kernel/trace/filter.hpp ./gecode/kernel/trace/general.hpp \
+	./gecode/kernel/trace/print.hpp ./gecode/kernel/trace/recorder.hpp ./gecode/kernel/trace/tracer.hpp \
+	./gecode/kernel/trace/traits.hpp ./gecode/kernel/var-imp.hpp ./gecode/kernel/var-type.hpp \
+	./gecode/kernel/var.hpp ./gecode/kernel/view.hpp ./gecode/minimodel.hh \
+	./gecode/minimodel/aliases.hpp ./gecode/minimodel/bool-expr.hpp ./gecode/minimodel/channel.hpp \
+	./gecode/minimodel/exception.hpp ./gecode/minimodel/float-expr.hpp ./gecode/minimodel/float-rel.hpp \
+	./gecode/minimodel/int-expr.hpp ./gecode/minimodel/int-rel.hpp ./gecode/minimodel/ipl.hpp \
+	./gecode/minimodel/ldsb.hpp ./gecode/minimodel/matrix.hpp ./gecode/minimodel/optimize.hpp \
+	./gecode/minimodel/reg.hpp ./gecode/minimodel/set-expr.hpp ./gecode/minimodel/set-rel.hpp \
+	./gecode/search.hh ./gecode/search/bab.hpp ./gecode/search/base.hpp \
+	./gecode/search/build.hpp ./gecode/search/cutoff.hpp ./gecode/search/dfs.hpp \
+	./gecode/search/engine.hpp ./gecode/search/exception.hpp ./gecode/search/lds.hpp \
+	./gecode/search/options.hpp ./gecode/search/pbs.hpp ./gecode/search/rbs.hpp \
+	./gecode/search/sebs.hpp ./gecode/search/seq/dead.hh ./gecode/search/statistics.hpp \
+	./gecode/search/stop.hpp ./gecode/search/support.hh ./gecode/search/trace-recorder.hpp \
+	./gecode/search/tracer.hpp ./gecode/search/traits.hpp ./gecode/set.hh \
+	./gecode/set/array-traits.hpp ./gecode/set/array.hpp ./gecode/set/branch.hpp \
+	./gecode/set/branch/action.hpp ./gecode/set/branch/afc.hpp ./gecode/set/branch/assign.hpp \
+	./gecode/set/branch/chb.hpp ./gecode/set/branch/traits.hpp ./gecode/set/branch/val.hpp \
+	./gecode/set/branch/var.hpp ./gecode/set/exception.hpp ./gecode/set/int.hpp \
+	./gecode/set/limits.hpp ./gecode/set/trace.hpp ./gecode/set/trace/delta.hpp \
+	./gecode/set/trace/trace-view.hpp ./gecode/set/trace/traits.hpp ./gecode/set/var-imp.hpp \
+	./gecode/set/var-imp/delta.hpp ./gecode/set/var-imp/integerset.hpp ./gecode/set/var-imp/iter.hpp \
+	./gecode/set/var-imp/set.hpp ./gecode/set/var/print.hpp ./gecode/set/var/set.hpp \
+	./gecode/set/view.hpp ./gecode/set/view/cached.hpp ./gecode/set/view/complement.hpp \
+	./gecode/set/view/const.hpp ./gecode/set/view/print.hpp ./gecode/set/view/set.hpp \
+	./gecode/set/view/singleton.hpp ./gecode/support.hh ./gecode/support/allocator.hpp \
+	./gecode/support/auto-link.hpp ./gecode/support/bitset-base.hpp ./gecode/support/bitset-offset.hpp \
+	./gecode/support/bitset.hpp ./gecode/support/block-allocator.hpp ./gecode/support/cast.hpp \
+	./gecode/support/config.hpp ./gecode/support/dynamic-array.hpp ./gecode/support/dynamic-queue.hpp \
+	./gecode/support/dynamic-stack.hpp ./gecode/support/exception.hpp ./gecode/support/hash.hpp \
+	./gecode/support/heap.hpp ./gecode/support/hw-rnd.hpp ./gecode/support/int-type.hpp \
+	./gecode/support/macros.hpp ./gecode/support/marked-pointer.hpp ./gecode/support/random.hpp \
+	./gecode/support/ref-count.hpp ./gecode/support/run-jobs.hpp ./gecode/support/sort.hpp \
+	./gecode/support/static-stack.hpp ./gecode/support/thread.hpp ./gecode/support/thread/thread.hpp \
+	./gecode/support/timer.hpp ./test/flatzinc.hh ./test/test.hh \
+	./test/test.hpp 
+test/flatzinc/cumulatives_full_8$(OBJSUFFIX) test/flatzinc/cumulatives_full_8$(SBJSUFFIX): \
+	./gecode/driver.hh ./gecode/driver/options.hpp ./gecode/driver/script.hpp \
+	./gecode/flatzinc.hh ./gecode/flatzinc/ast.hh ./gecode/flatzinc/conexpr.hh \
+	./gecode/flatzinc/option.hh ./gecode/flatzinc/varspec.hh ./gecode/float.hh \
+	./gecode/float/array-traits.hpp ./gecode/float/array.hpp ./gecode/float/branch.hpp \
+	./gecode/float/branch/action.hpp ./gecode/float/branch/afc.hpp ./gecode/float/branch/assign.hpp \
+	./gecode/float/branch/chb.hpp ./gecode/float/branch/traits.hpp ./gecode/float/branch/val.hpp \
+	./gecode/float/branch/var.hpp ./gecode/float/channel.hpp ./gecode/float/exception.hpp \
+	./gecode/float/limits.hpp ./gecode/float/nextafter.hpp ./gecode/float/num.hpp \
+	./gecode/float/rounding.hpp ./gecode/float/trace.hpp ./gecode/float/trace/delta.hpp \
+	./gecode/float/trace/trace-view.hpp ./gecode/float/trace/traits.hpp ./gecode/float/val.hpp \
+	./gecode/float/var-imp.hpp ./gecode/float/var-imp/delta.hpp ./gecode/float/var-imp/float.hpp \
+	./gecode/float/var/float.hpp ./gecode/float/var/print.hpp ./gecode/float/view.hpp \
+	./gecode/float/view/float.hpp ./gecode/float/view/minus.hpp ./gecode/float/view/offset.hpp \
+	./gecode/float/view/print.hpp ./gecode/float/view/rel-test.hpp ./gecode/float/view/scale.hpp \
+	./gecode/gist.hh ./gecode/gist/gist.hpp ./gecode/int.hh \
+	./gecode/int/array-traits.hpp ./gecode/int/array.hpp ./gecode/int/branch.hpp \
+	./gecode/int/branch/action.hpp ./gecode/int/branch/afc.hpp ./gecode/int/branch/assign.hpp \
+	./gecode/int/branch/chb.hpp ./gecode/int/branch/traits.hpp ./gecode/int/branch/val.hpp \
+	./gecode/int/branch/var.hpp ./gecode/int/channel.hpp ./gecode/int/div.hh \
+	./gecode/int/div.hpp ./gecode/int/exception.hpp ./gecode/int/extensional.hpp \
+	./gecode/int/extensional/dfa.hpp ./gecode/int/extensional/tuple-set.hpp ./gecode/int/int-set-1.hpp \
+	./gecode/int/int-set-2.hpp ./gecode/int/ipl.hpp ./gecode/int/irt.hpp \
+	./gecode/int/limits.hpp ./gecode/int/propagator.hpp ./gecode/int/reify.hpp \
+	./gecode/int/trace.hpp ./gecode/int/trace/bool-delta.hpp ./gecode/int/trace/bool-trace-view.hpp \
+	./gecode/int/trace/int-delta.hpp ./gecode/int/trace/int-trace-view.hpp ./gecode/int/trace/traits.hpp \
+	./gecode/int/var-imp.hpp ./gecode/int/var-imp/bool.hpp ./gecode/int/var-imp/delta.hpp \
+	./gecode/int/var-imp/int.hpp ./gecode/int/var/bool.hpp ./gecode/int/var/int.hpp \
+	./gecode/int/var/print.hpp ./gecode/int/view.hpp ./gecode/int/view/bool-test.hpp \
+	./gecode/int/view/bool.hpp ./gecode/int/view/cached.hpp ./gecode/int/view/constint.hpp \
+	./gecode/int/view/int.hpp ./gecode/int/view/iter.hpp ./gecode/int/view/minus.hpp \
+	./gecode/int/view/neg-bool.hpp ./gecode/int/view/offset.hpp ./gecode/int/view/print.hpp \
+	./gecode/int/view/rel-test.hpp ./gecode/int/view/scale.hpp ./gecode/int/view/zero.hpp \
+	./gecode/iter.hh ./gecode/iter/ranges-add.hpp ./gecode/iter/ranges-append.hpp \
+	./gecode/iter/ranges-array.hpp ./gecode/iter/ranges-cache.hpp ./gecode/iter/ranges-compl.hpp \
+	./gecode/iter/ranges-diff.hpp ./gecode/iter/ranges-empty.hpp ./gecode/iter/ranges-inter.hpp \
+	./gecode/iter/ranges-list.hpp ./gecode/iter/ranges-map.hpp ./gecode/iter/ranges-minmax.hpp \
+	./gecode/iter/ranges-minus.hpp ./gecode/iter/ranges-negative.hpp ./gecode/iter/ranges-offset.hpp \
+	./gecode/iter/ranges-operations.hpp ./gecode/iter/ranges-positive.hpp ./gecode/iter/ranges-rangelist.hpp \
+	./gecode/iter/ranges-scale.hpp ./gecode/iter/ranges-singleton-append.hpp ./gecode/iter/ranges-singleton.hpp \
+	./gecode/iter/ranges-size.hpp ./gecode/iter/ranges-union.hpp ./gecode/iter/ranges-values.hpp \
+	./gecode/iter/values-array.hpp ./gecode/iter/values-bitset.hpp ./gecode/iter/values-bitsetoffset.hpp \
+	./gecode/iter/values-inter.hpp ./gecode/iter/values-list.hpp ./gecode/iter/values-map.hpp \
+	./gecode/iter/values-minus.hpp ./gecode/iter/values-negative.hpp ./gecode/iter/values-offset.hpp \
+	./gecode/iter/values-positive.hpp ./gecode/iter/values-ranges.hpp ./gecode/iter/values-singleton.hpp \
+	./gecode/iter/values-union.hpp ./gecode/iter/values-unique.hpp ./gecode/kernel.hh \
+	./gecode/kernel/archive.hpp ./gecode/kernel/branch/action.hpp ./gecode/kernel/branch/afc.hpp \
+	./gecode/kernel/branch/chb.hpp ./gecode/kernel/branch/filter.hpp ./gecode/kernel/branch/merit.hpp \
+	./gecode/kernel/branch/print.hpp ./gecode/kernel/branch/tiebreak.hpp ./gecode/kernel/branch/traits.hpp \
+	./gecode/kernel/branch/val-commit.hpp ./gecode/kernel/branch/val-sel-commit.hpp ./gecode/kernel/branch/val-sel.hpp \
+	./gecode/kernel/branch/val.hpp ./gecode/kernel/branch/var.hpp ./gecode/kernel/branch/view-sel.hpp \
+	./gecode/kernel/branch/view-val.hpp ./gecode/kernel/branch/view.hpp ./gecode/kernel/core.hpp \
+	./gecode/kernel/data/array.hpp ./gecode/kernel/data/rnd.hpp ./gecode/kernel/data/shared-array.hpp \
+	./gecode/kernel/data/shared-data.hpp ./gecode/kernel/exception.hpp ./gecode/kernel/gpi.hpp \
+	./gecode/kernel/macros.hpp ./gecode/kernel/memory/allocators.hpp ./gecode/kernel/memory/config.hpp \
+	./gecode/kernel/memory/manager.hpp ./gecode/kernel/memory/region.hpp ./gecode/kernel/modevent.hpp \
+	./gecode/kernel/propagator/advisor.hpp ./gecode/kernel/propagator/pattern.hpp ./gecode/kernel/propagator/subscribed.hpp \
+	./gecode/kernel/propagator/wait.hpp ./gecode/kernel/range-list.hpp ./gecode/kernel/shared-object.hpp \
+	./gecode/kernel/shared-space-data.hpp ./gecode/kernel/trace/filter.hpp ./gecode/kernel/trace/general.hpp \
+	./gecode/kernel/trace/print.hpp ./gecode/kernel/trace/recorder.hpp ./gecode/kernel/trace/tracer.hpp \
+	./gecode/kernel/trace/traits.hpp ./gecode/kernel/var-imp.hpp ./gecode/kernel/var-type.hpp \
+	./gecode/kernel/var.hpp ./gecode/kernel/view.hpp ./gecode/minimodel.hh \
+	./gecode/minimodel/aliases.hpp ./gecode/minimodel/bool-expr.hpp ./gecode/minimodel/channel.hpp \
+	./gecode/minimodel/exception.hpp ./gecode/minimodel/float-expr.hpp ./gecode/minimodel/float-rel.hpp \
+	./gecode/minimodel/int-expr.hpp ./gecode/minimodel/int-rel.hpp ./gecode/minimodel/ipl.hpp \
+	./gecode/minimodel/ldsb.hpp ./gecode/minimodel/matrix.hpp ./gecode/minimodel/optimize.hpp \
+	./gecode/minimodel/reg.hpp ./gecode/minimodel/set-expr.hpp ./gecode/minimodel/set-rel.hpp \
+	./gecode/search.hh ./gecode/search/bab.hpp ./gecode/search/base.hpp \
+	./gecode/search/build.hpp ./gecode/search/cutoff.hpp ./gecode/search/dfs.hpp \
+	./gecode/search/engine.hpp ./gecode/search/exception.hpp ./gecode/search/lds.hpp \
+	./gecode/search/options.hpp ./gecode/search/pbs.hpp ./gecode/search/rbs.hpp \
+	./gecode/search/sebs.hpp ./gecode/search/seq/dead.hh ./gecode/search/statistics.hpp \
+	./gecode/search/stop.hpp ./gecode/search/support.hh ./gecode/search/trace-recorder.hpp \
+	./gecode/search/tracer.hpp ./gecode/search/traits.hpp ./gecode/set.hh \
+	./gecode/set/array-traits.hpp ./gecode/set/array.hpp ./gecode/set/branch.hpp \
+	./gecode/set/branch/action.hpp ./gecode/set/branch/afc.hpp ./gecode/set/branch/assign.hpp \
+	./gecode/set/branch/chb.hpp ./gecode/set/branch/traits.hpp ./gecode/set/branch/val.hpp \
+	./gecode/set/branch/var.hpp ./gecode/set/exception.hpp ./gecode/set/int.hpp \
+	./gecode/set/limits.hpp ./gecode/set/trace.hpp ./gecode/set/trace/delta.hpp \
+	./gecode/set/trace/trace-view.hpp ./gecode/set/trace/traits.hpp ./gecode/set/var-imp.hpp \
+	./gecode/set/var-imp/delta.hpp ./gecode/set/var-imp/integerset.hpp ./gecode/set/var-imp/iter.hpp \
+	./gecode/set/var-imp/set.hpp ./gecode/set/var/print.hpp ./gecode/set/var/set.hpp \
+	./gecode/set/view.hpp ./gecode/set/view/cached.hpp ./gecode/set/view/complement.hpp \
+	./gecode/set/view/const.hpp ./gecode/set/view/print.hpp ./gecode/set/view/set.hpp \
+	./gecode/set/view/singleton.hpp ./gecode/support.hh ./gecode/support/allocator.hpp \
+	./gecode/support/auto-link.hpp ./gecode/support/bitset-base.hpp ./gecode/support/bitset-offset.hpp \
+	./gecode/support/bitset.hpp ./gecode/support/block-allocator.hpp ./gecode/support/cast.hpp \
+	./gecode/support/config.hpp ./gecode/support/dynamic-array.hpp ./gecode/support/dynamic-queue.hpp \
+	./gecode/support/dynamic-stack.hpp ./gecode/support/exception.hpp ./gecode/support/hash.hpp \
+	./gecode/support/heap.hpp ./gecode/support/hw-rnd.hpp ./gecode/support/int-type.hpp \
+	./gecode/support/macros.hpp ./gecode/support/marked-pointer.hpp ./gecode/support/random.hpp \
+	./gecode/support/ref-count.hpp ./gecode/support/run-jobs.hpp ./gecode/support/sort.hpp \
+	./gecode/support/static-stack.hpp ./gecode/support/thread.hpp ./gecode/support/thread/thread.hpp \
+	./gecode/support/timer.hpp ./test/flatzinc.hh ./test/test.hh \
+	./test/test.hpp 
 test/flatzinc/cutstock$(OBJSUFFIX) test/flatzinc/cutstock$(SBJSUFFIX): \
 	./gecode/driver.hh ./gecode/driver/options.hpp ./gecode/driver/script.hpp \
 	./gecode/flatzinc.hh ./gecode/flatzinc/ast.hh ./gecode/flatzinc/conexpr.hh \
@@ -33466,8 +34226,7 @@ test/flatzinc/on_restart_complete$(OBJSUFFIX) test/flatzinc/on_restart_complete$
 	./gecode/support/heap.hpp ./gecode/support/hw-rnd.hpp ./gecode/support/int-type.hpp \
 	./gecode/support/macros.hpp ./gecode/support/marked-pointer.hpp ./gecode/support/random.hpp \
 	./gecode/support/ref-count.hpp ./gecode/support/run-jobs.hpp ./gecode/support/sort.hpp \
-	./gecode/support/static-stack.hpp ./gecode/support/thread.hpp ./gecode/support/thread/none.hpp \
-	./gecode/support/thread/pthreads.hpp ./gecode/support/thread/thread.hpp ./gecode/support/thread/windows.hpp \
+	./gecode/support/static-stack.hpp ./gecode/support/thread.hpp ./gecode/support/thread/thread.hpp \
 	./gecode/support/timer.hpp ./test/flatzinc.hh ./test/test.hh \
 	./test/test.hpp 
 test/flatzinc/on_restart_last_val_bool$(OBJSUFFIX) test/flatzinc/on_restart_last_val_bool$(SBJSUFFIX): \
@@ -33562,8 +34321,7 @@ test/flatzinc/on_restart_last_val_bool$(OBJSUFFIX) test/flatzinc/on_restart_last
 	./gecode/support/heap.hpp ./gecode/support/hw-rnd.hpp ./gecode/support/int-type.hpp \
 	./gecode/support/macros.hpp ./gecode/support/marked-pointer.hpp ./gecode/support/random.hpp \
 	./gecode/support/ref-count.hpp ./gecode/support/run-jobs.hpp ./gecode/support/sort.hpp \
-	./gecode/support/static-stack.hpp ./gecode/support/thread.hpp ./gecode/support/thread/none.hpp \
-	./gecode/support/thread/pthreads.hpp ./gecode/support/thread/thread.hpp ./gecode/support/thread/windows.hpp \
+	./gecode/support/static-stack.hpp ./gecode/support/thread.hpp ./gecode/support/thread/thread.hpp \
 	./gecode/support/timer.hpp ./test/flatzinc.hh ./test/test.hh \
 	./test/test.hpp 
 test/flatzinc/on_restart_last_val_float$(OBJSUFFIX) test/flatzinc/on_restart_last_val_float$(SBJSUFFIX): \
@@ -33658,8 +34416,7 @@ test/flatzinc/on_restart_last_val_float$(OBJSUFFIX) test/flatzinc/on_restart_las
 	./gecode/support/heap.hpp ./gecode/support/hw-rnd.hpp ./gecode/support/int-type.hpp \
 	./gecode/support/macros.hpp ./gecode/support/marked-pointer.hpp ./gecode/support/random.hpp \
 	./gecode/support/ref-count.hpp ./gecode/support/run-jobs.hpp ./gecode/support/sort.hpp \
-	./gecode/support/static-stack.hpp ./gecode/support/thread.hpp ./gecode/support/thread/none.hpp \
-	./gecode/support/thread/pthreads.hpp ./gecode/support/thread/thread.hpp ./gecode/support/thread/windows.hpp \
+	./gecode/support/static-stack.hpp ./gecode/support/thread.hpp ./gecode/support/thread/thread.hpp \
 	./gecode/support/timer.hpp ./test/flatzinc.hh ./test/test.hh \
 	./test/test.hpp 
 test/flatzinc/on_restart_last_val_int$(OBJSUFFIX) test/flatzinc/on_restart_last_val_int$(SBJSUFFIX): \
@@ -33754,8 +34511,7 @@ test/flatzinc/on_restart_last_val_int$(OBJSUFFIX) test/flatzinc/on_restart_last_
 	./gecode/support/heap.hpp ./gecode/support/hw-rnd.hpp ./gecode/support/int-type.hpp \
 	./gecode/support/macros.hpp ./gecode/support/marked-pointer.hpp ./gecode/support/random.hpp \
 	./gecode/support/ref-count.hpp ./gecode/support/run-jobs.hpp ./gecode/support/sort.hpp \
-	./gecode/support/static-stack.hpp ./gecode/support/thread.hpp ./gecode/support/thread/none.hpp \
-	./gecode/support/thread/pthreads.hpp ./gecode/support/thread/thread.hpp ./gecode/support/thread/windows.hpp \
+	./gecode/support/static-stack.hpp ./gecode/support/thread.hpp ./gecode/support/thread/thread.hpp \
 	./gecode/support/timer.hpp ./test/flatzinc.hh ./test/test.hh \
 	./test/test.hpp 
 test/flatzinc/on_restart_last_val_set$(OBJSUFFIX) test/flatzinc/on_restart_last_val_set$(SBJSUFFIX): \
@@ -33850,8 +34606,7 @@ test/flatzinc/on_restart_last_val_set$(OBJSUFFIX) test/flatzinc/on_restart_last_
 	./gecode/support/heap.hpp ./gecode/support/hw-rnd.hpp ./gecode/support/int-type.hpp \
 	./gecode/support/macros.hpp ./gecode/support/marked-pointer.hpp ./gecode/support/random.hpp \
 	./gecode/support/ref-count.hpp ./gecode/support/run-jobs.hpp ./gecode/support/sort.hpp \
-	./gecode/support/static-stack.hpp ./gecode/support/thread.hpp ./gecode/support/thread/none.hpp \
-	./gecode/support/thread/pthreads.hpp ./gecode/support/thread/thread.hpp ./gecode/support/thread/windows.hpp \
+	./gecode/support/static-stack.hpp ./gecode/support/thread.hpp ./gecode/support/thread/thread.hpp \
 	./gecode/support/timer.hpp ./test/flatzinc.hh ./test/test.hh \
 	./test/test.hpp 
 test/flatzinc/on_restart_sol_bool$(OBJSUFFIX) test/flatzinc/on_restart_sol_bool$(SBJSUFFIX): \
@@ -33946,8 +34701,7 @@ test/flatzinc/on_restart_sol_bool$(OBJSUFFIX) test/flatzinc/on_restart_sol_bool$
 	./gecode/support/heap.hpp ./gecode/support/hw-rnd.hpp ./gecode/support/int-type.hpp \
 	./gecode/support/macros.hpp ./gecode/support/marked-pointer.hpp ./gecode/support/random.hpp \
 	./gecode/support/ref-count.hpp ./gecode/support/run-jobs.hpp ./gecode/support/sort.hpp \
-	./gecode/support/static-stack.hpp ./gecode/support/thread.hpp ./gecode/support/thread/none.hpp \
-	./gecode/support/thread/pthreads.hpp ./gecode/support/thread/thread.hpp ./gecode/support/thread/windows.hpp \
+	./gecode/support/static-stack.hpp ./gecode/support/thread.hpp ./gecode/support/thread/thread.hpp \
 	./gecode/support/timer.hpp ./test/flatzinc.hh ./test/test.hh \
 	./test/test.hpp 
 test/flatzinc/on_restart_sol_float$(OBJSUFFIX) test/flatzinc/on_restart_sol_float$(SBJSUFFIX): \
@@ -34042,8 +34796,7 @@ test/flatzinc/on_restart_sol_float$(OBJSUFFIX) test/flatzinc/on_restart_sol_floa
 	./gecode/support/heap.hpp ./gecode/support/hw-rnd.hpp ./gecode/support/int-type.hpp \
 	./gecode/support/macros.hpp ./gecode/support/marked-pointer.hpp ./gecode/support/random.hpp \
 	./gecode/support/ref-count.hpp ./gecode/support/run-jobs.hpp ./gecode/support/sort.hpp \
-	./gecode/support/static-stack.hpp ./gecode/support/thread.hpp ./gecode/support/thread/none.hpp \
-	./gecode/support/thread/pthreads.hpp ./gecode/support/thread/thread.hpp ./gecode/support/thread/windows.hpp \
+	./gecode/support/static-stack.hpp ./gecode/support/thread.hpp ./gecode/support/thread/thread.hpp \
 	./gecode/support/timer.hpp ./test/flatzinc.hh ./test/test.hh \
 	./test/test.hpp 
 test/flatzinc/on_restart_sol_int$(OBJSUFFIX) test/flatzinc/on_restart_sol_int$(SBJSUFFIX): \
@@ -34138,8 +34891,7 @@ test/flatzinc/on_restart_sol_int$(OBJSUFFIX) test/flatzinc/on_restart_sol_int$(S
 	./gecode/support/heap.hpp ./gecode/support/hw-rnd.hpp ./gecode/support/int-type.hpp \
 	./gecode/support/macros.hpp ./gecode/support/marked-pointer.hpp ./gecode/support/random.hpp \
 	./gecode/support/ref-count.hpp ./gecode/support/run-jobs.hpp ./gecode/support/sort.hpp \
-	./gecode/support/static-stack.hpp ./gecode/support/thread.hpp ./gecode/support/thread/none.hpp \
-	./gecode/support/thread/pthreads.hpp ./gecode/support/thread/thread.hpp ./gecode/support/thread/windows.hpp \
+	./gecode/support/static-stack.hpp ./gecode/support/thread.hpp ./gecode/support/thread/thread.hpp \
 	./gecode/support/timer.hpp ./test/flatzinc.hh ./test/test.hh \
 	./test/test.hpp 
 test/flatzinc/on_restart_sol_set$(OBJSUFFIX) test/flatzinc/on_restart_sol_set$(SBJSUFFIX): \
@@ -34234,7 +34986,6 @@ test/flatzinc/on_restart_sol_set$(OBJSUFFIX) test/flatzinc/on_restart_sol_set$(S
 	./gecode/support/heap.hpp ./gecode/support/hw-rnd.hpp ./gecode/support/int-type.hpp \
 	./gecode/support/macros.hpp ./gecode/support/marked-pointer.hpp ./gecode/support/random.hpp \
 	./gecode/support/ref-count.hpp ./gecode/support/run-jobs.hpp ./gecode/support/sort.hpp \
-	./gecode/support/static-stack.hpp ./gecode/support/thread.hpp ./gecode/support/thread/none.hpp \
-	./gecode/support/thread/pthreads.hpp ./gecode/support/thread/thread.hpp ./gecode/support/thread/windows.hpp \
+	./gecode/support/static-stack.hpp ./gecode/support/thread.hpp ./gecode/support/thread/thread.hpp \
 	./gecode/support/timer.hpp ./test/flatzinc.hh ./test/test.hh \
 	./test/test.hpp 


### PR DESCRIPTION
Some of the tests were still using the deps from the old threads code and so wouldn't compile when using the autoconf build system.

It also now has the deps for the cumulatives constraint tests for MiniZinc.