### PR TITLE
cmake: Add missing check for `__builtin_popcountll()`.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -258,6 +258,13 @@ if (HAVE_BUILTIN_FFSL)
   set(GECODE_HAS_BUILTIN_FFSL "/**/")
 endif ()
 
+# Check for popcount
+check_c_source_compiles("
+  int main() { return __builtin_popcountll(0); }" HAVE_BUILTIN_POPCOUNTLL)
+if (HAVE_BUILTIN_POPCOUNTLL)
+  set(GECODE_HAS_BUILTIN_POPCOUNTLL "/**/")
+endif ()
+
 # Process config.hpp using autoconf rules.
 list(LENGTH CONFIG length)
 math(EXPR length "${length} - 1")


### PR DESCRIPTION
The autoconf build system has this already.