### PR TITLE
Use std::chrono::steady_clock for timers.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,12 +213,6 @@ endif ()
 
 include(CheckSymbolExists)
 check_symbol_exists(mmap sys/mman.h HAVE_MMAP)
-check_symbol_exists(gettimeofday sys/time.h HAVE_GETTIMEOFDAY)
-if (HAVE_GETTIMEOFDAY)
-  set(GECODE_USE_GETTIMEOFDAY 1)
-else ()
-  set(GECODE_USE_CLOCK 1)
-endif ()
 
 # Check for inline.
 include(CheckCSourceCompiles)

--- a/configure
+++ b/configure
@@ -6537,21 +6537,6 @@ $as_echo "no" >&6; }
 
 
 
-  ac_fn_cxx_check_header_mongrel "$LINENO" "sys/time.h" "ac_cv_header_sys_time_h" "$ac_includes_default"
-if test "x$ac_cv_header_sys_time_h" = xyes; then :
-
-$as_echo "#define GECODE_USE_GETTIMEOFDAY 1" >>confdefs.h
-
-else
-
-$as_echo "#define GECODE_USE_CLOCK 1" >>confdefs.h
-
-fi
-
-
-
-
-
 # Check whether --with-freelist32-size-max was given.
 if test "${with_freelist32_size_max+set}" = set; then :
   withval=$with_freelist32_size_max;

--- a/gecode.m4
+++ b/gecode.m4
@@ -1519,12 +1519,6 @@ AC_DEFUN([AC_GECODE_THREADS],[
   fi
 ])
 
-AC_DEFUN([AC_GECODE_TIMER],[
-  AC_CHECK_HEADER(sys/time.h,
-  [AC_DEFINE(GECODE_USE_GETTIMEOFDAY,1,[Use gettimeofday for time-measurement])],
-  [AC_DEFINE(GECODE_USE_CLOCK,1,[Use clock() for time-measurement])])
-])
-
 dnl check whether we have suifficiently recent versions of flex/bison
 AC_DEFUN([AC_GECODE_FLEXBISON],
   [AC_CHECK_TOOL(HAVEFLEX, flex)

--- a/gecode/support/config.hpp.in
+++ b/gecode/support/config.hpp.in
@@ -114,12 +114,6 @@
 /* Whether to use unfair mutexes on macOS */
 #undef GECODE_USE_OSX_UNFAIR_MUTEX
 
-/* Use clock() for time-measurement */
-#undef GECODE_USE_CLOCK
-
-/* Use gettimeofday for time-measurement */
-#undef GECODE_USE_GETTIMEOFDAY
-
 /* Gecode version */
 #undef GECODE_VERSION
 


### PR DESCRIPTION
This improves portability by not using `gettimeofday()` or `clock()`.