### PR TITLE
Allow par identifiers var array initialisers for FlatZinc

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -1215,6 +1215,7 @@ FLATZINCTESTSRC0 = \
   test/flatzinc/magicsq_5.cpp \
   test/flatzinc/oss.cpp \
   test/flatzinc/steiner_triples.cpp \
+  test/flatzinc/subtyping.cpp \
   test/flatzinc/timetabling.cpp \
   test/flatzinc/trucking.cpp \
 	test/flatzinc/on_restart_complete.cpp \

--- a/changelog.in
+++ b/changelog.in
@@ -71,6 +71,13 @@ Let's see.
 
 [ENTRY]
 Module: flatzinc
+What:   bug
+Rank:   minor
+[DESCRIPTION]
+Allow par identifiers in var array initialisers.
+
+[ENTRY]
+Module: flatzinc
 What:   change
 Rank:   minor
 [DESCRIPTION]

--- a/gecode/flatzinc.hh
+++ b/gecode/flatzinc.hh
@@ -529,6 +529,7 @@ namespace Gecode { namespace FlatZinc {
           object(new OnRestartData());
         }
       }
+      bool initialized() const { return object() != nullptr; }
       OnRestartData& operator ()() {
         return *static_cast<OnRestartData*>(object());
       };

--- a/gecode/flatzinc/flatzinc.cpp
+++ b/gecode/flatzinc/flatzinc.cpp
@@ -2010,7 +2010,7 @@ namespace Gecode { namespace FlatZinc {
   bool
   FlatZincSpace::slave(const MetaInfo& mi) {
     if (mi.type() == MetaInfo::RESTART) {
-      if (restart_data().mark_complete) {
+      if (restart_data.initialized() && restart_data().mark_complete) {
         // Fail the space
         this->fail();
         // Return true to signal we are in the global search space

--- a/gecode/flatzinc/parser.tab.cpp
+++ b/gecode/flatzinc/parser.tab.cpp
@@ -2906,7 +2906,7 @@ yyreduce:
       {
         SymbolEntry e;
         ParserState* pp = static_cast<ParserState*>(parm);
-        if (pp->symbols.get((yyvsp[0].sValue), e) && e.t == ST_INTVAR)
+        if (pp->symbols.get((yyvsp[0].sValue), e) && (e.t == ST_INTVAR || e.t == ST_INT))
           (yyval.varSpec) = new IntVarSpec(Alias(e.i),false,false);
         else {
           pp->err << "Error: undefined identifier for type int " << (yyvsp[0].sValue)
@@ -2986,7 +2986,7 @@ yyreduce:
       {
         SymbolEntry e;
         ParserState* pp = static_cast<ParserState*>(parm);
-        if (pp->symbols.get((yyvsp[0].sValue), e) && e.t == ST_FLOATVAR)
+        if (pp->symbols.get((yyvsp[0].sValue), e) && (e.t == ST_FLOATVAR || e.t == ST_FLOAT))
           (yyval.varSpec) = new FloatVarSpec(Alias(e.i),false,false);
         else {
           pp->err << "Error: undefined identifier for type float " << (yyvsp[0].sValue)
@@ -3065,7 +3065,7 @@ yyreduce:
       {
         SymbolEntry e;
         ParserState* pp = static_cast<ParserState*>(parm);
-        if (pp->symbols.get((yyvsp[0].sValue), e) && e.t == ST_BOOLVAR)
+        if (pp->symbols.get((yyvsp[0].sValue), e) && (e.t == ST_BOOLVAR || e.t == ST_BOOL))
           (yyval.varSpec) = new BoolVarSpec(Alias(e.i),false,false);
         else {
           pp->err << "Error: undefined identifier for type bool " << (yyvsp[0].sValue)
@@ -3144,7 +3144,7 @@ yyreduce:
       {
         ParserState* pp = static_cast<ParserState*>(parm);
         SymbolEntry e;
-        if (pp->symbols.get((yyvsp[0].sValue), e) && e.t == ST_SETVAR)
+        if (pp->symbols.get((yyvsp[0].sValue), e) && (e.t == ST_SETVAR || e.t == ST_SET))
           (yyval.varSpec) = new SetVarSpec(Alias(e.i),false,false);
         else {
           pp->err << "Error: undefined identifier for type set " << (yyvsp[0].sValue)

--- a/gecode/flatzinc/parser.yxx
+++ b/gecode/flatzinc/parser.yxx
@@ -1327,7 +1327,7 @@ int_init :
       {
         SymbolEntry e;
         ParserState* pp = static_cast<ParserState*>(parm);
-        if (pp->symbols.get($1, e) && e.t == ST_INTVAR)
+        if (pp->symbols.get($1, e) && (e.t == ST_INTVAR || e.t == ST_INT))
           $$ = new IntVarSpec(Alias(e.i),false,false);
         else {
           pp->err << "Error: undefined identifier for type int " << $1
@@ -1384,7 +1384,7 @@ float_init :
       {
         SymbolEntry e;
         ParserState* pp = static_cast<ParserState*>(parm);
-        if (pp->symbols.get($1, e) && e.t == ST_FLOATVAR)
+        if (pp->symbols.get($1, e) && (e.t == ST_FLOATVAR || e.t == ST_FLOAT))
           $$ = new FloatVarSpec(Alias(e.i),false,false);
         else {
           pp->err << "Error: undefined identifier for type float " << $1
@@ -1439,7 +1439,7 @@ bool_init :
       {
         SymbolEntry e;
         ParserState* pp = static_cast<ParserState*>(parm);
-        if (pp->symbols.get($1, e) && e.t == ST_BOOLVAR)
+        if (pp->symbols.get($1, e) && (e.t == ST_BOOLVAR || e.t == ST_BOOL))
           $$ = new BoolVarSpec(Alias(e.i),false,false);
         else {
           pp->err << "Error: undefined identifier for type bool " << $1
@@ -1492,7 +1492,7 @@ set_init :
       {
         ParserState* pp = static_cast<ParserState*>(parm);
         SymbolEntry e;
-        if (pp->symbols.get($1, e) && e.t == ST_SETVAR)
+        if (pp->symbols.get($1, e) && (e.t == ST_SETVAR || e.t == ST_SET))
           $$ = new SetVarSpec(Alias(e.i),false,false);
         else {
           pp->err << "Error: undefined identifier for type set " << $1

--- a/test/flatzinc/subtyping.cpp
+++ b/test/flatzinc/subtyping.cpp
@@ -1,0 +1,77 @@
+/* -*- mode: C++; c-basic-offset: 2; indent-tabs-mode: nil -*- */
+/*
+ *  Main authors:
+ *     Jason Nguyen <jason.nguyen@monash.edu>
+ *
+ *  Copyright:
+ *     Jason nguyen, 2023
+ *
+ *  This file is part of Gecode, the generic constraint
+ *  development environment:
+ *     http://www.gecode.org
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining
+ *  a copy of this software and associated documentation files (the
+ *  "Software"), to deal in the Software without restriction, including
+ *  without limitation the rights to use, copy, modify, merge, publish,
+ *  distribute, sublicense, and/or sell copies of the Software, and to
+ *  permit persons to whom the Software is furnished to do so, subject to
+ *  the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be
+ *  included in all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ *  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ *  MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ *  LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ *  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ *  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+#include "test/flatzinc.hh"
+
+namespace Test { namespace FlatZinc {
+
+  namespace {
+    /// Helper class to create and register tests
+    class Create {
+    public:
+
+      /// Perform creation and registration
+      Create(void) {
+        (void) new FlatZincTest("subtyping::1",
+R"FZN(
+bool: pb = true;
+int: pi = 1;
+float: pf = 1.5;
+set of int: ps = {1, 3};
+var bool: vb :: output_var;
+var 1..1: vi :: output_var;
+var 1.5..1.5: vf :: output_var;
+var set of 1..1: vs :: output_var;
+array [1..3] of var bool: vba = [vb, pb, true];
+array [1..3] of var int: via = [vi, pi, 3];
+array [1..3] of var float: vfa = [vf, pf, 3.5];
+array [1..3] of var set of int: vsa = [vs, ps, {1}];
+constraint bool_eq(vb, pb);
+constraint set_card(vs, pi);
+solve satisfy;
+)FZN",
+R"OUT(vb = true;
+vf = 1.5;
+vi = 1;
+vs = 1..1;
+----------
+)OUT");
+      }
+    };
+
+    Create c;
+  }
+
+}}
+
+// STATISTICS: test-flatzinc


### PR DESCRIPTION
Previously, the parser would reject par identifiers inside the initializers for arrays of var declarations, but this should (theoretically) be allowed (although the MiniZinc compiler has now been changed to never produce this).

Also adds a missing check for `restart_data` preventing a possible crash.