### PR TITLE
Remove obsolete AC_GECODE_TIMER M4 macro from configure.ac.in

### DIFF
--- a/configure.ac.in
+++ b/configure.ac.in
@@ -155,9 +155,6 @@ AC_GECODE_CHECK_ARITH
 dnl checking for thread support
 AC_GECODE_THREADS
 
-dnl checking for timer to use
-AC_GECODE_TIMER
-
 dnl checking for freelist sizes to use
 AC_GECODE_FREELIST_32_SIZE
 AC_GECODE_FREELIST_64_SIZE


### PR DESCRIPTION
In bc31c318b73b47a085551fc3a6fa70dba89dad28 Gecode's timer handling was unified to std::chrono::steady_clock.  This removed the need for checking at build time for which timer to use and AC_GECODE_TIMER M4 macro was removed that tested for them but the configure.ac.in still had the call, breaking autotools build.