### PR TITLE
cmake: Only write config.hpp when changed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -271,7 +271,7 @@ foreach (i RANGE ${length})
   string(REPLACE "<semi>" ";" line "${line}")
   set(CONFIG_OUT "${CONFIG_OUT}${line}")
 endforeach ()
-file(WRITE ${GECODE_BINARY_DIR}/gecode/support/config.hpp
+file(CONFIGURE OUTPUT ${GECODE_BINARY_DIR}/gecode/support/config.hpp CONTENT
 "/* gecode/support/config.hpp.  Generated from config.hpp.in by configure.  */
 /* gecode/support/config.hpp.in.  Generated from configure.ac by autoheader.  */
 


### PR DESCRIPTION
By using `file(CONFIGURE)` instead of `file(WRITE)`, the file output will only be written if it has changed. This allows for running `cmake` to pick up other (possible) changes without triggering a full rebuild as happens when the `config.hpp` file has changed.