### PR TITLE
Fixing one off in the uniform_on_restart bug.

### DIFF
--- a/gecode/flatzinc/flatzinc.cpp
+++ b/gecode/flatzinc/flatzinc.cpp
@@ -2164,7 +2164,7 @@ namespace Gecode { namespace FlatZinc {
         for (size_t i = 0; i < restart_data().uniform_range_float.size(); ++i) {
           const auto& range = restart_data().uniform_range_float[i];
           /* rndVal will be an element of [range.first, range.second] */
-          const FloatVal rndVal = (static_cast<FloatVal>(_random(INT_MAX)) / INT_MAX)*(range.second - range.first) + range.first;
+          const FloatVal rndVal = (static_cast<FloatVal>(_random(INT_MAX)) / (INT_MAX - 1))*(range.second - range.first) + range.first;
           rel(*this, on_restart_fv[base + i], FRT_EQ, rndVal);
         }
         base += restart_data().uniform_range_float.size();

--- a/gecode/flatzinc/flatzinc.cpp
+++ b/gecode/flatzinc/flatzinc.cpp
@@ -2040,7 +2040,7 @@ namespace Gecode { namespace FlatZinc {
         // Assign uniform_int random values 
         for (size_t i = 0; i < restart_data().uniform_range_int.size(); ++i) {
           const auto& range = restart_data().uniform_range_int[i];
-          const int rndVal = range.first + _random(static_cast<unsigned int>(range.second - range.first));
+          const int rndVal = range.first + _random(static_cast<unsigned int>(range.second - range.first + 1));
           rel(*this, on_restart_iv[base + i], IRT_EQ, rndVal);
         }
         base += restart_data().uniform_range_int.size();


### PR DESCRIPTION
This pull request makes a small but important fix to the random value assignment logic in the `gecode/flatzinc/flatzinc.cpp` file. The change ensures that the generated random integer values can include the upper bound of the specified range, correcting an off-by-one error. This is happened becasue `Rnd _random` input domain is `[lower_bound, upper_bound)` and `+ 1` to correct set to `[lower_bound, upper_bound]`, and it is effect to [`uniform_on_restart`](https://docs.minizinc.dev/en/stable/lib-experimental-on_restart.html#mzn-ref-experimental-on-restart-uniform-on-restart) constraints.

* Fixed the calculation of random values for uniform integer ranges to include the upper bound by changing the random range from `(range.second - range.first)` to `(range.second - range.first + 1)`.