### PR TITLE
Dispose random view selectors

### DIFF
--- a/changelog.in
+++ b/changelog.in
@@ -92,6 +92,16 @@ Restore the legacy GIST_STATIC_LIBS compatibility macro for static
 Windows clients. GECODE_STATIC_LIBS remains the preferred spelling.
 
 [ENTRY]
+Module: kernel
+What:   bug
+Rank:   minor
+Issue:  62
+Thanks: k0stjap
+[DESCRIPTION]
+Dispose the random view selector used by random variable branching so
+its random generator handle is released when the brancher is discarded.
+
+[ENTRY]
 Module: float
 What:   bug
 Rank:   minor

--- a/gecode/kernel/branch/view-sel.hpp
+++ b/gecode/kernel/branch/view-sel.hpp
@@ -182,6 +182,10 @@ namespace Gecode {
     //@{
     /// Create copy during cloning
     virtual ViewSel<View>* copy(Space& home);
+    /// Whether dispose must always be called (that is, notice is needed)
+    virtual bool notice(void) const;
+    /// Delete view selection
+    virtual void dispose(Space& home);
     //@}
   };
 
@@ -538,6 +542,16 @@ namespace Gecode {
   ViewSel<View>*
   ViewSelRnd<View>::copy(Space& home) {
     return new (home) ViewSelRnd<View>(home,*this);
+  }
+  template<class View>
+  forceinline bool
+  ViewSelRnd<View>::notice(void) const {
+    return true;
+  }
+  template<class View>
+  forceinline void
+  ViewSelRnd<View>::dispose(Space&) {
+    r.~Rnd();
   }
 
 


### PR DESCRIPTION
## Summary
- Add `notice()` and `dispose()` to the random view selector so its `Rnd` handle is destroyed when branchers are discarded.
- Mirror the existing random value selector resource-management pattern.
- Add a changelog entry thanking @k0stjap.

Fixes #62.

## Validation
- `cmake -S . -B /tmp/gecode-int-var-rnd-dispose-build -DCMAKE_BUILD_TYPE=Debug -DGECODE_ENABLE_EXAMPLES=OFF -DGECODE_ENABLE_GIST=OFF -DGECODE_ENABLE_QT=OFF`
- `cmake --build /tmp/gecode-int-var-rnd-dispose-build --target gecode-test -j 8`
- `/tmp/gecode-int-var-rnd-dispose-build/bin/gecode-test -iter 1 -test ^Int::Branch::Dense::3`
- `/tmp/gecode-int-var-rnd-dispose-build/bin/gecode-test -iter 1 -test ^Int::Branch::Sparse::3`
- `git diff --check`

Note: I also started the full `Int::Branch` family, observed passing progress, and stopped it because it was too broad for this resource-management fix.
