### PR TITLE
Fix empty vector argument array construction

### DIFF
--- a/changelog.in
+++ b/changelog.in
@@ -102,6 +102,17 @@ Dispose the random view selector used by random variable branching so
 its random generator handle is released when the brancher is discarded.
 
 [ENTRY]
+Module: kernel
+What:   bug
+Rank:   minor
+Issue:  205
+Thanks: intractabilis
+[DESCRIPTION]
+Fix construction of argument arrays from empty `std::vector` instances
+so zero-length copies do not take the address of a nonexistent first
+element.
+
+[ENTRY]
 Module: float
 What:   bug
 Rank:   minor

--- a/gecode/kernel/data/array.hpp
+++ b/gecode/kernel/data/array.hpp
@@ -1557,7 +1557,8 @@ namespace Gecode {
   ArgArrayBase<T>::ArgArrayBase(const std::vector<T>& aa)
     : n(static_cast<int>(aa.size())),
       capacity(n < onstack_size ? onstack_size : n), a(allocate(n)) {
-    heap.copy<T>(a,&aa[0],n);
+    if (n > 0)
+      heap.copy<T>(a,aa.data(),n);
   }
 
   template<class T>

--- a/test/array.cpp
+++ b/test/array.cpp
@@ -34,6 +34,8 @@
 #include <gecode/kernel.hh>
 #include <gecode/int.hh>
 
+#include <vector>
+
 #include "test/test.hh"
 
 /// Check the test result and handle failed test
@@ -189,6 +191,32 @@ namespace Test {
       return new TestSpace(*this);
     }
   };
+
+  /// Test name prefix for vector construction
+  static const std::string vectorPrefix("Array::Vector::");
+
+  /// %Class for testing construction from empty vectors
+  class EmptyVector : public Test::Base {
+  public:
+    /// Initialize test
+    EmptyVector(void) : Test::Base(vectorPrefix + "Empty") {}
+    /// Perform actual tests
+    bool run(void) {
+      std::vector<int> ints;
+      Gecode::IntArgs ia(ints);
+      if (ia.size() != 0)
+        return false;
+
+      std::vector<Gecode::IntVar> intVars;
+      Gecode::IntVarArgs iva(intVars);
+      if (iva.size() != 0)
+        return false;
+
+      std::vector<Gecode::BoolVar> boolVars;
+      Gecode::BoolVarArgs bva(boolVars);
+      return bva.size() == 0;
+    }
+  } emptyVectorTest;
 
   /// %Class for testing the VarArray iterator
   class VarArrayIterator : public Iterator {


### PR DESCRIPTION
## Summary
- Fix construction of argument arrays from empty `std::vector` instances by avoiding `&aa[0]` when the vector is empty.
- Add a regression test for empty vector construction of `IntArgs`, `IntVarArgs`, and `BoolVarArgs`.
- Add a changelog entry thanking @intractabilis.

Fixes #205.

## Validation
- `cmake -S . -B /tmp/gecode-empty-vector-args-build -DCMAKE_BUILD_TYPE=Debug -DGECODE_ENABLE_EXAMPLES=OFF -DGECODE_ENABLE_GIST=OFF -DGECODE_ENABLE_QT=OFF`
- `cmake --build /tmp/gecode-empty-vector-args-build --target gecode-test -j 8`
- `/tmp/gecode-empty-vector-args-build/bin/gecode-test -test Array::Vector::Empty`
- `git diff --check`
