### PR TITLE
Fix GCC solution loss during recomputation

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -1141,6 +1141,7 @@ FLATZINCTESTSRC0 = \
   test/flatzinc/empty_domain_2.cpp \
   test/flatzinc/int_set_as_type1.cpp \
   test/flatzinc/int_set_as_type2.cpp \
+  test/flatzinc/issue166.cpp \
   test/flatzinc/jobshop.cpp \
   test/flatzinc/no_warn_empty_domain.cpp \
   test/flatzinc/output_test.cpp \

--- a/changelog.in
+++ b/changelog.in
@@ -82,8 +82,9 @@ Rank:   major
 Issue:  166
 Thanks: Mats Carlsson
 [DESCRIPTION]
-Fix domain-level global cardinality propagation losing solutions when search
-recomputation applies several branch choices before propagation.
+Fix domain-level global cardinality propagation losing solutions by counting
+assigned variables twice and retaining stale conflict marks when cardinality
+bounds shrink.
 
 [ENTRY]
 Module: flatzinc

--- a/changelog.in
+++ b/changelog.in
@@ -76,6 +76,16 @@ first-class CMake package for downstream consumers, refreshes the
 autoconf build path, and updates CI coverage for current platforms.
 
 [ENTRY]
+Module: int
+What:   bug
+Rank:   major
+Issue:  166
+Thanks: Mats Carlsson
+[DESCRIPTION]
+Fix domain-level global cardinality propagation losing solutions when search
+recomputation applies several branch choices before propagation.
+
+[ENTRY]
 Module: flatzinc
 What:   new
 Rank:   minor

--- a/cmake/GecodeSources.cmake
+++ b/cmake/GecodeSources.cmake
@@ -293,6 +293,7 @@ set(GECODE_TEST_SOURCES
   test/flatzinc/golomb.cpp
   test/flatzinc/int_set_as_type1.cpp
   test/flatzinc/int_set_as_type2.cpp
+  test/flatzinc/issue166.cpp
   test/flatzinc/jobshop.cpp
   test/flatzinc/jobshop2x2.cpp
   test/flatzinc/knights.cpp

--- a/gecode/int/gcc/dom-sup.hpp
+++ b/gecode/int/gcc/dom-sup.hpp
@@ -1268,7 +1268,8 @@ namespace Gecode { namespace Int { namespace GCC {
               v->maxlow(k[i].max() - (inc_lbc));
               if (v->kmin() == v->kmax())
                 v->cap(LBC,k[i].max() - (inc_lbc));
-              v->card_conflict(rm);
+              int matched = inc_ubc - v->kcount();
+              v->card_conflict(std::min(rm, matched));
             }
           }
         }

--- a/gecode/int/gcc/dom-sup.hpp
+++ b/gecode/int/gcc/dom-sup.hpp
@@ -1417,7 +1417,8 @@ namespace Gecode { namespace Int { namespace GCC {
         ValNode* v = vars[i]->first()->getVal();
         vars[i]->first()->free(bc);
         GECODE_ME_CHECK(x[i].eq(home, v->val));
-        v->inc();
+        if (bc == UBC)
+          v->inc();
       }
 
     for (int i = n_val; i--; ) {
@@ -1765,5 +1766,4 @@ namespace Gecode { namespace Int { namespace GCC {
 }}}
 
 // STATISTICS: int-prop
-
 

--- a/test/flatzinc/issue166.cpp
+++ b/test/flatzinc/issue166.cpp
@@ -35,17 +35,17 @@
 namespace Test { namespace FlatZinc {
 
   namespace {
-    /// Check that recomputation does not lose a solution
-    bool check(const std::string& output) {
+    /// Check that recomputation does not lose solutions
+    bool check(const std::string& output, int expected,
+               const std::string& representative) {
       const std::string separator = "----------\n";
       int solutions = 0;
       for (std::string::size_type p = 0;
            (p = output.find(separator,p)) != std::string::npos;
            p += separator.size())
         solutions++;
-      return (solutions == 11) &&
-        (output.find("A = 3;\nB = 1;\nC = 3;\nD = 1;\nE = 2;\nG = 3;\n")
-         != std::string::npos);
+      return (solutions == expected) &&
+        (output.find(representative) != std::string::npos);
     }
 
     /// Helper class to create and register test
@@ -53,7 +53,24 @@ namespace Test { namespace FlatZinc {
     public:
       /// Perform creation and registration
       Create(void) {
-        (void) new FlatZincTest("Issue166",
+        (void) new FlatZincTest("Issue166::Original",
+"predicate gecode_global_cardinality(array [int] of var int: x, array [int] of int: cover, array [int] of var int: counts);\n\
+var {1,3}: A :: output_var;\n\
+var 2..3: B :: output_var;\n\
+var 2..3: C :: output_var;\n\
+var 2..3: D :: output_var;\n\
+var 2..5: E :: output_var;\n\
+var 1..4: F :: output_var;\n\
+var 2..3: G :: output_var;\n\
+var 2..3: H :: output_var;\n\
+constraint gecode_global_cardinality([A,D,1,3,3,C,1,H,B],[1,2,3],[G,F,E]) :: domain;\n\
+solve :: int_search([A,B,C,D,E,F,G,H],anti_first_fail,indomain_min,complete) satisfy;\n",
+          "", true, {"-a"}, [] (const std::string& output) {
+            return check(output, 26,
+                         "A = 1;\nB = 2;\nC = 3;\nD = 3;\nE = 5;\n"
+                         "F = 1;\nG = 3;\nH = 3;\n");
+          });
+        (void) new FlatZincTest("Issue166::Minimized",
 "predicate gecode_global_cardinality(array [int] of var int: x, array [int] of int: cover, array [int] of var int: counts);\n\
 var 1..3: A :: output_var;\n\
 var 1..3: B :: output_var;\n\
@@ -63,7 +80,11 @@ var 2..3: E :: output_var;\n\
 var 2..3: G :: output_var;\n\
 constraint gecode_global_cardinality([3,A,D,G,E],[1,2,3],[1,B,C]) :: domain;\n\
 solve :: int_search([D,A,E,B],input_order,indomain_random,complete) satisfy;\n",
-          "", true, {"-a", "-r", "0", "-c-d", "8"}, check);
+          "", true, {"-a", "-r", "0", "-c-d", "8"},
+          [] (const std::string& output) {
+            return check(output, 11,
+                         "A = 3;\nB = 1;\nC = 3;\nD = 1;\nE = 2;\nG = 3;\n");
+          });
       }
     };
 

--- a/test/flatzinc/issue166.cpp
+++ b/test/flatzinc/issue166.cpp
@@ -1,0 +1,75 @@
+/* -*- mode: C++; c-basic-offset: 2; indent-tabs-mode: nil -*- */
+/*
+ *  Main authors:
+ *     Mikael Zayenz Lagerkvist <lagerkvist@gecode.dev>
+ *
+ *  Copyright:
+ *     Mikael Zayenz Lagerkvist, 2026
+ *
+ *  This file is part of Gecode, the generic constraint
+ *  development environment:
+ *     http://www.gecode.dev
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining
+ *  a copy of this software and associated documentation files (the
+ *  "Software"), to deal in the Software without restriction, including
+ *  without limitation the rights to use, copy, modify, merge, publish,
+ *  distribute, sublicense, and/or sell copies of the Software, and to
+ *  permit persons to whom the Software is furnished to do so, subject to
+ *  the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be
+ *  included in all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ *  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ *  MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ *  LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ *  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ *  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "test/flatzinc.hh"
+
+namespace Test { namespace FlatZinc {
+
+  namespace {
+    /// Check that recomputation does not lose a solution
+    bool check(const std::string& output) {
+      const std::string separator = "----------\n";
+      int solutions = 0;
+      for (std::string::size_type p = 0;
+           (p = output.find(separator,p)) != std::string::npos;
+           p += separator.size())
+        solutions++;
+      return (solutions == 11) &&
+        (output.find("A = 3;\nB = 1;\nC = 3;\nD = 1;\nE = 2;\nG = 3;\n")
+         != std::string::npos);
+    }
+
+    /// Helper class to create and register test
+    class Create {
+    public:
+      /// Perform creation and registration
+      Create(void) {
+        (void) new FlatZincTest("Issue166",
+"predicate gecode_global_cardinality(array [int] of var int: x, array [int] of int: cover, array [int] of var int: counts);\n\
+var 1..3: A :: output_var;\n\
+var 1..3: B :: output_var;\n\
+var 1..3: C :: output_var;\n\
+var 1..2: D :: output_var;\n\
+var 2..3: E :: output_var;\n\
+var 2..3: G :: output_var;\n\
+constraint gecode_global_cardinality([3,A,D,G,E],[1,2,3],[1,B,C]) :: domain;\n\
+solve :: int_search([D,A,E,B],input_order,indomain_random,complete) satisfy;\n",
+          "", true, {"-a", "-r", "0", "-c-d", "8"}, check);
+      }
+    };
+
+    Create c;
+  }
+
+}}
+
+// STATISTICS: test-flatzinc


### PR DESCRIPTION
Domain-level global cardinality propagation could lose solutions in two related matching-state paths.

First, assigned variables were counted in both the upper- and lower-bound narrowing passes when recomputation replayed several choices before propagation. Second, when a variable cardinality maximum shrank by more than the number of currently matched edges, the propagator retained an impossible conflict count. That stale conflict mark could remove supported value edges.

Count assigned variables only in the upper-bound pass, and cap conflict bookkeeping by the number of genuinely matched edges (excluding already-counted assigned occurrences). This retains the existing rematching strength without leaving stale conflicts.

The FlatZinc regression now covers both the original deterministic issue model (26 solutions, including a formerly missing assignment) and the minimized random-search model (11 solutions, including its formerly missing assignment).

Verified with:

- both focused FlatZinc regressions;
- the original model at recomputation distances 1, 2, 4, 8, and 16;
- the minimized model across those five distances and seeds 0 through 9;
- all 24 integer GCC test families at five randomized iterations;
- the exact variable-cardinality domain-propagation seed used to check fixpoint equivalence after cloning.

Closes #166.
