### PR TITLE
Fix zero-cost edges in the TSP example

### DIFF
--- a/changelog.in
+++ b/changelog.in
@@ -117,6 +117,16 @@ Do not create empty MiniZinc directories when FlatZinc is disabled in an
 Autotools build.
 
 [ENTRY]
+Module: example
+What: bug
+Rank: minor
+Issue: 151
+Thanks: Ioannis Papatsoris
+[DESCRIPTION]
+Treat zero entries in the TSP example as valid zero-cost edges. This lets the
+br17 instance reach its optimum.
+
+[ENTRY]
 Module: flatzinc
 What:   new
 Rank:   minor

--- a/examples/tsp.cpp
+++ b/examples/tsp.cpp
@@ -244,12 +244,6 @@ public:
     // Cost matrix
     IntArgs c(n*n, p.d());
 
-    // Disallow disconnected nodes
-    for (int i=0; i<n; i++)
-      for (int j=0; j<n; j++)
-        if (p.d(i,j) == 0)
-          rel(*this, succ[i], IRT_NQ, j);
-
     // Cost of each edge
     IntVarArgs costs(*this, n, Int::Limits::min, Int::Limits::max);
 


### PR DESCRIPTION
The br17 example reports 87 instead of the published optimum of 39 because it treats every zero in the distance matrix as a missing edge. br17 contains valid off-diagonal zero-cost edges.

Remove that extra filtering and let `circuit` enforce the tour. The example then reaches 39; the two smaller instances retain costs 2276 and 22.

Checks:

- configured a Release Ninja build and built the `tsp` target;
- ran instances 0, 1, and 2 to optimality, obtaining 2276, 22, and 39;
- audited all bundled matrices: only br17 contains off-diagonal zero-cost edges; and
- ran `git diff --check`.

Closes #151.
