### PR TITLE
Preserve Gist mode with statistics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1432,6 +1432,7 @@ if(BUILD_TESTING)
       Search::DFS::Sol::Binary::Nary::Binary::1::1::1)
     if(GECODE_ENABLE_FLATZINC)
       list(INSERT GECODE_CHECK_TESTS 1
+        FlatZinc::Options
         FlatZinc::magic_square
         FlatZinc::blackbox)
     endif()

--- a/Makefile.in
+++ b/Makefile.in
@@ -1363,7 +1363,7 @@ CHECKTESTS = Branch::Int::Dense::3 \
 	Set::Wait
 
 ifeq "@enable_flatzinc@" "yes"
-CHECKTESTS += FlatZinc::blackbox
+CHECKTESTS += FlatZinc::Options FlatZinc::blackbox
 BLACKBOXCHECKENV = \
 	GECODE_TEST_BLACKBOX_EXEC=$(abspath $(BLACKBOXEXEC)) \
 	GECODE_TEST_BLACKBOX_DLL=$(abspath $(BLACKBOXDLL)) \

--- a/changelog.in
+++ b/changelog.in
@@ -148,6 +148,16 @@ make progress.
 
 [ENTRY]
 Module: flatzinc
+What: bug
+Rank: minor
+Issue: 99
+Thanks: Mikael Zayenz Lagerkvist
+[DESCRIPTION]
+Keep an explicitly selected Gist execution mode when FlatZinc statistics are
+requested.
+
+[ENTRY]
+Module: flatzinc
 What:   new
 Rank:   minor
 Thanks: Jip J. Dekker

--- a/changelog.in
+++ b/changelog.in
@@ -151,7 +151,6 @@ Module: flatzinc
 What: bug
 Rank: minor
 Issue: 99
-Thanks: Mikael Zayenz Lagerkvist
 [DESCRIPTION]
 Keep an explicitly selected Gist execution mode when FlatZinc statistics are
 requested.

--- a/changelog.in
+++ b/changelog.in
@@ -153,7 +153,8 @@ Rank: minor
 Issue: 99
 [DESCRIPTION]
 Keep an explicitly selected Gist execution mode when FlatZinc statistics are
-requested.
+requested, and report an error instead of silently running in solution mode
+when Gist support is unavailable.
 
 [ENTRY]
 Module: flatzinc

--- a/gecode/flatzinc.hh
+++ b/gecode/flatzinc.hh
@@ -329,7 +329,7 @@ namespace Gecode { namespace FlatZinc {
       if (_time_limit.value()) {
         _time.value(_time_limit.value());
       }
-      if (_stat.value())
+      if (_stat.value() && (_mode.value() == Gecode::SM_SOLUTION))
         _mode.value(Gecode::SM_STAT);
     }
 

--- a/gecode/flatzinc/flatzinc.cpp
+++ b/gecode/flatzinc/flatzinc.cpp
@@ -2039,6 +2039,11 @@ namespace Gecode { namespace FlatZinc {
   void
   FlatZincSpace::run(std::ostream& out, const Printer& p,
                       const FlatZincOptions& opt, Support::Timer& t_total) {
+#ifndef GECODE_HAS_GIST
+    if (opt.mode() == SM_GIST)
+      throw FlatZinc::Error("FlatZinc",
+        "Gist mode is unavailable in this build");
+#endif
     switch (_method) {
     case MIN:
     case MAX:

--- a/test/flatzinc.cpp
+++ b/test/flatzinc.cpp
@@ -93,6 +93,15 @@ namespace Test { namespace FlatZinc {
 
     GistStatisticsMode gist_statistics_mode;
 
+#ifndef GECODE_HAS_GIST
+    /// Verify that unavailable Gist mode is rejected instead of running search.
+    FlatZincErrorTest gist_unavailable(
+      "Options::GistUnavailable",
+      "var 1..1: x :: output_var;\nsolve satisfy;\n",
+      {"-mode", "gist", "-s"},
+      "Gist mode is unavailable in this build");
+#endif
+
   }
 
   FlatZincTest::FlatZincTest(const std::string& name, const std::string& source,

--- a/test/flatzinc.cpp
+++ b/test/flatzinc.cpp
@@ -65,6 +65,34 @@ namespace Test { namespace FlatZinc {
 
     TupleSetAutoRepresentation tuple_set_auto_representation;
 
+    /// Verify that statistics do not override an explicit Gist mode.
+    class GistStatisticsMode : public Base {
+    private:
+      static Gecode::ScriptMode mode(std::vector<std::string> args) {
+        Gecode::FlatZinc::FlatZincOptions opt("Gecode/FlatZinc");
+        std::string cmd("fzn-gecode");
+        int argc = static_cast<int>(args.size()) + 1;
+        std::vector<char*> argv(argc);
+        argv[0] = const_cast<char*>(cmd.data());
+        for (int i=1; i<argc; i++)
+          argv[i] = const_cast<char*>(args[i-1].data());
+        opt.parse(argc,argv.data());
+        return opt.mode();
+      }
+    public:
+      GistStatisticsMode(void)
+        : Base("FlatZinc::Options::GistStatisticsMode") {}
+
+      virtual bool run(void) {
+        return
+          (mode({"-s"}) == Gecode::SM_STAT) &&
+          (mode({"-mode", "gist", "-s"}) == Gecode::SM_GIST) &&
+          (mode({"-s", "-mode", "gist"}) == Gecode::SM_GIST);
+      }
+    };
+
+    GistStatisticsMode gist_statistics_mode;
+
   }
 
   FlatZincTest::FlatZincTest(const std::string& name, const std::string& source,


### PR DESCRIPTION
FlatZinc option parsing changed the execution mode to stat whenever -s was present, even when -mode gist had been selected explicitly. Argument order did not help because the override happened after parsing.

Keep -s as the statistics shorthand for ordinary solution mode, but preserve an explicit Gist mode in either argument order.

When Gist support is compiled out, reject Gist execution before search with a clear FlatZinc error instead of silently falling through to ordinary solution mode. The run-level regression parses and prepares a real model, then verifies that -mode gist -s raises the unavailable-mode error without producing a solution.

The focused FlatZinc option tests are included in both the CMake and Autotools fast-check selections.

Checks:
- Gist-disabled CMake Release build of fzn-gecode and gecode-test
- FlatZinc::Options::GistStatisticsMode
- FlatZinc::Options::GistUnavailable
- Gist-disabled fzn-gecode -mode gist -s process exits 1 with the expected error
- Gist-enabled CMake Release build of fzn-gecode
- git diff --check

Closes #99.