### PR TITLE
Modernize Gecode attribution domains

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,11 @@
+Christian Schulte <schulte@gecode.dev> <schulte@gecode.org>
+Christian Schulte <schulte@gecode.dev> <cschulte@kth.se>
+Christian Schulte <schulte@gecode.dev> <cschulte@sics.se>
+
+Guido Tack <tack@gecode.dev> <tack@gecode.org>
+Guido Tack <tack@gecode.dev> <guido.tack@monash.edu>
+Guido Tack <tack@gecode.dev> <guido.tack@me.com>
+
+Mikael Zayenz Lagerkvist <lagerkvist@gecode.dev> <lagerkvist@gecode.org>
+Mikael Zayenz Lagerkvist <lagerkvist@gecode.dev> <zayenz@gecode.org>
+Mikael Zayenz Lagerkvist <lagerkvist@gecode.dev> <zayenz@gmail.com>

--- a/gecode/flatzinc/blackbox-backend.cpp
+++ b/gecode/flatzinc/blackbox-backend.cpp
@@ -11,7 +11,7 @@
  *
  *  This file is part of Gecode, the generic constraint
  *  development environment:
- *     http://www.gecode.org
+ *     http://www.gecode.dev
  *
  *  Permission is hereby granted, free of charge, to any person obtaining
  *  a copy of this software and associated documentation files (the

--- a/gecode/flatzinc/blackbox-backend.hh
+++ b/gecode/flatzinc/blackbox-backend.hh
@@ -11,7 +11,7 @@
  *
  *  This file is part of Gecode, the generic constraint
  *  development environment:
- *     http://www.gecode.org
+ *     http://www.gecode.dev
  *
  *  Permission is hereby granted, free of charge, to any person obtaining
  *  a copy of this software and associated documentation files (the

--- a/gecode/flatzinc/blackbox-propagator.cpp
+++ b/gecode/flatzinc/blackbox-propagator.cpp
@@ -11,7 +11,7 @@
  *
  *  This file is part of Gecode, the generic constraint
  *  development environment:
- *     http://www.gecode.org
+ *     http://www.gecode.dev
  *
  *  Permission is hereby granted, free of charge, to any person obtaining
  *  a copy of this software and associated documentation files (the

--- a/gecode/flatzinc/blackbox.hh
+++ b/gecode/flatzinc/blackbox.hh
@@ -11,7 +11,7 @@
  *
  *  This file is part of Gecode, the generic constraint
  *  development environment:
- *     http://www.gecode.org
+ *     http://www.gecode.dev
  *
  *  Permission is hereby granted, free of charge, to any person obtaining
  *  a copy of this software and associated documentation files (the


### PR DESCRIPTION
## Summary

- Replace remaining `gecode.org` attribution references with `gecode.dev` on top of current `origin/main`.
- Add `.mailmap` entries to canonicalize historical Christian, Guido, and Mikael Git identities to `gecode.dev` addresses.

## Validation

- `rg "gecode\\.org|Mikael Lagerkvist|Mikael lagerkvist" .`
- `git check-mailmap --stdin` for the historical Christian, Guido, and Mikael identities found in commit history.

No build or test suite was run; this is a metadata-only attribution update.