### PR TITLE
Fix restart float test and vcpkg Windows CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -428,9 +428,9 @@ jobs:
       uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: ${{ runner.temp }}\vcpkg-binary-cache
-        key: vcpkg-${{ runner.os }}-x64-windows-d015e31e90838a4c9dfa3eed45979bc70d9357fc-${{ hashFiles('vcpkg.json') }}
+        key: vcpkg-${{ runner.os }}-x64-windows-37bb045f3c7a747d3e5d1c13b6fe6a0aec4b5d00-${{ hashFiles('vcpkg.json') }}
         restore-keys: |
-          vcpkg-${{ runner.os }}-x64-windows-d015e31e90838a4c9dfa3eed45979bc70d9357fc-
+          vcpkg-${{ runner.os }}-x64-windows-37bb045f3c7a747d3e5d1c13b6fe6a0aec4b5d00-
 
     - name: Setup vcpkg
       shell: pwsh
@@ -439,7 +439,7 @@ jobs:
         $vcpkgBinaryCache = Join-Path $env:RUNNER_TEMP "vcpkg-binary-cache"
         New-Item -ItemType Directory -Force -Path $vcpkgBinaryCache | Out-Null
         git clone https://github.com/microsoft/vcpkg $vcpkgRoot
-        git -C $vcpkgRoot checkout d015e31e90838a4c9dfa3eed45979bc70d9357fc
+        git -C $vcpkgRoot checkout 37bb045f3c7a747d3e5d1c13b6fe6a0aec4b5d00
         & (Join-Path $vcpkgRoot "bootstrap-vcpkg.bat") -disableMetrics
         "VCPKG_ROOT=$vcpkgRoot" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
         "VCPKG_DEFAULT_BINARY_CACHE=$vcpkgBinaryCache" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append

--- a/test/flatzinc/on_restart_sol_float.cpp
+++ b/test/flatzinc/on_restart_sol_float.cpp
@@ -47,7 +47,7 @@ R"FZN(predicate gecode_on_restart_sol_float(var float: input,var float: out);
 predicate gecode_on_restart_status(var int: s);
 predicate int_eq_imp(var int: a,var int: b,var bool: r);
 var 1..3: x:: output_var;
-var float: y:: output_var;
+var 1.0..3.0: y:: output_var;
 var 1.0..3.0: X_INTRODUCED_2_ ::var_is_introduced :: is_defined_var;
 var 1.0..3.0: X_INTRODUCED_3_ ::var_is_introduced ;
 var bool: X_INTRODUCED_4_ ::var_is_introduced :: is_defined_var;

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "gecode",
   "version-string": "6.4.0",
-  "builtin-baseline": "01e2abc86d9a6e2bee0f6355eb7f8650b6cea100",
+  "builtin-baseline": "37bb045f3c7a747d3e5d1c13b6fe6a0aec4b5d00",
   "dependencies": [
     "mpfr"
   ]


### PR DESCRIPTION
This fixes two independent failures exposed by the current test matrix.

The `on_restart::sol_float` fixture left its output float unbounded even though the expected first solution assumes a lower bound of `1.0`. Restart initialization uses the variable lower bound when no previous solution exists, so the test printed Gecode’s minimum representable float. The output now uses the same `1.0..3.0` domain as the test input and restart variables.

The Windows vcpkg job was pinned before microsoft/vcpkg#53437, where the GMP port still referenced an unavailable Autoconf 2.71 package. The workflow checkout, cache key, and manifest baseline now use vcpkg commit `37bb045f3c7a747d3e5d1c13b6fe6a0aec4b5d00`. That baseline selects GMP `6.3.0#5` and its reachable `autoconf2.71-2.71-4` package. GMP intentionally remains on Autoconf 2.71 because its port documents broken dumpbin detection with 2.72.

Validation:
- reproduced the original `FlatZinc::on_restart::sol_float` failure on macOS
- rebuilt `gecode-test` natively
- exact restart-float test passes for all five default iterations
- all 12 `FlatZinc::on_restart::*` tests pass
- `vcpkg.json` and the workflow parse successfully
- downloaded the pinned MSYS2 package and matched its SHA-512
- diff hygiene passes